### PR TITLE
fix/missing-package-versions

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,9 +4,15 @@
 
 export const NPM_REGISTRY_URL = 'https://registry.npmjs.org'
 export const JSDELIVR_CDN_URL = 'https://cdn.jsdelivr.net/npm'
-export const MAX_CONCURRENT_REQUESTS = 80
+export const MAX_CONCURRENT_REQUESTS = 150
 export const CACHE_TTL = 5 * 60 * 1000 // 5 minutes in milliseconds
-export const REQUEST_TIMEOUT = 30000 // 30 seconds in milliseconds
+export const REQUEST_TIMEOUT = 60000 // 60 seconds in milliseconds
+
+/**
+ * Registry selection: 'jsdelivr' for fast CDN lookups, 'npm' for direct npm registry
+ * Set to 'npm' to use npm registry by default instead of jsdelivr
+ */
+export const DEFAULT_REGISTRY: 'jsdelivr' | 'npm' = 'jsdelivr'
 
 /**
  * Package manager lock files

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -62,6 +62,8 @@ export function findClosestMinorVersion(
 
     const installedMajor = semver.major(coercedInstalled)
     const installedMinor = semver.minor(coercedInstalled)
+    const installedPatch = semver.patch(coercedInstalled)
+
     let bestMinorVersion: string | null = null
     let bestMinorValue = -1
 
@@ -83,13 +85,17 @@ export function findClosestMinorVersion(
       return bestMinorVersion
     }
 
-    // Fallback: find highest patch that satisfies current range
-    let bestVersion: string | null = null
+    // Fallback: find highest patch version in same major.minor that's higher than installed
+    let bestPatchVersion: string | null = null
     for (const version of allVersions) {
       try {
-        if (semver.satisfies(version, installedVersion) && semver.gt(version, coercedInstalled)) {
-          if (!bestVersion || semver.gt(version, bestVersion)) {
-            bestVersion = version
+        const major = semver.major(version)
+        const minor = semver.minor(version)
+        const patch = semver.patch(version)
+        // Same major and minor, but higher patch
+        if (major === installedMajor && minor === installedMinor && patch > installedPatch) {
+          if (!bestPatchVersion || semver.gt(version, bestPatchVersion)) {
+            bestPatchVersion = version
           }
         }
       } catch {
@@ -97,7 +103,7 @@ export function findClosestMinorVersion(
       }
     }
 
-    return bestVersion
+    return bestPatchVersion
   } catch {
     return null
   }


### PR DESCRIPTION
- Fix version comparison logic to properly detect patch updates within the same major.minor version
- Improve jsdelivr registry to explicitly fetch current version instead of relying on coercion
- Simplify npm registry implementation by replacing undici pool with native fetch API
- Add DEFAULT_REGISTRY configuration to allow switching between jsdelivr and npm registries
- Increase REQUEST_TIMEOUT from 30s to 60s for better reliability
- Increase MAX_CONCURRENT_REQUESTS from 80 to 150 for improved throughput