### PR TITLE
chore/perf-for-fetching

### DIFF
--- a/src/services/jsdelivr-registry.ts
+++ b/src/services/jsdelivr-registry.ts
@@ -60,96 +60,9 @@ async function fetchPackageJsonFromJsdelivr(
 }
 
 /**
- * Fetches package data from jsdelivr CDN with fallback to npm registry.
- * Makes simultaneous requests for @latest, @major version, and current version.
- * @param packageName - The npm package name
- * @param currentVersion - The current version to extract major from (optional)
- * @returns Package data with latest version and all versions
- */
-async function fetchPackageFromJsdelivr(
-  packageName: string,
-  currentVersion?: string
-): Promise<{ latestVersion: string; allVersions: string[] }> {
-  // Check cache first
-  const cached = packageCache.get(packageName)
-  if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
-    return cached.data
-  }
-
-  try {
-    // Determine major version from current version if provided
-    const majorVersion = currentVersion
-      ? semver.major(semver.coerce(currentVersion) || '0.0.0').toString()
-      : null
-
-    // Prepare requests: always fetch @latest, @major if we have a current version
-    const requests: Array<Promise<{ version: string } | null>> = [
-      fetchPackageJsonFromJsdelivr(packageName, 'latest'),
-    ]
-
-    if (majorVersion) {
-      requests.push(fetchPackageJsonFromJsdelivr(packageName, majorVersion))
-    }
-
-    // Execute all requests simultaneously
-    const results = await Promise.all(requests)
-
-    const latestResult = results[0]
-    const majorResult = results[1]
-
-    if (!latestResult) {
-      // jsdelivr doesn't have this package, fallback to npm registry
-      const npmData = await getAllPackageData([packageName])
-      const data = npmData.get(packageName) || { latestVersion: 'unknown', allVersions: [] }
-
-      // Cache the result
-      packageCache.set(packageName, {
-        data,
-        timestamp: Date.now(),
-      })
-
-      return data
-    }
-
-    const latestVersion = latestResult.version
-    const allVersions = [latestVersion]
-
-    // Add the major version result if different from latest
-    if (majorResult && majorResult.version !== latestVersion) {
-      allVersions.push(majorResult.version)
-    }
-
-    const result = {
-      latestVersion,
-      allVersions: allVersions.sort(semver.rcompare),
-    }
-
-    // Cache the result
-    packageCache.set(packageName, {
-      data: result,
-      timestamp: Date.now(),
-    })
-
-    return result
-  } catch (error) {
-    // Fallback to npm registry on any error
-    const npmData = await getAllPackageData([packageName])
-    const data = npmData.get(packageName) || { latestVersion: 'unknown', allVersions: [] }
-
-    // Cache the result
-    packageCache.set(packageName, {
-      data,
-      timestamp: Date.now(),
-    })
-
-    return data
-  }
-}
-
-/**
  * Fetches package version data from jsdelivr CDN for multiple packages.
  * Uses undici connection pool for blazing fast performance with connection reuse.
- * Falls back to npm registry if jsdelivr doesn't have the package.
+ * Falls back to npm registry in batches if jsdelivr doesn't have packages.
  * @param packageNames - Array of package names to fetch
  * @param currentVersions - Optional map of package names to their current versions
  * @param onProgress - Optional progress callback
@@ -169,22 +82,103 @@ export async function getAllPackageDataFromJsdelivr(
   const total = packageNames.length
   let completedCount = 0
 
-  // Fire all requests simultaneously - undici pool handles concurrency internally
-  // No need for p-limit - the pool's connection limit controls concurrency
+  // Track packages that need npm fallback (not found on jsDelivr)
+  const failedPackages: string[] = []
+
+  // Fire all jsDelivr requests simultaneously - undici pool handles concurrency internally
   const allPromises = packageNames.map(async (packageName) => {
     const currentVersion = currentVersions?.get(packageName)
-    const data = await fetchPackageFromJsdelivr(packageName, currentVersion)
-    packageData.set(packageName, data)
 
-    completedCount++
+    // Try to get from cache first
+    const cached = packageCache.get(packageName)
+    if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+      packageData.set(packageName, cached.data)
+      completedCount++
+      if (onProgress) {
+        onProgress(packageName, completedCount, total)
+      }
+      return
+    }
 
-    if (onProgress) {
-      onProgress(packageName, completedCount, total)
+    try {
+      // Determine major version from current version if provided
+      const majorVersion = currentVersion
+        ? semver.major(semver.coerce(currentVersion) || '0.0.0').toString()
+        : null
+
+      // Prepare requests: always fetch @latest, @major if we have a current version
+      const requests: Array<Promise<{ version: string } | null>> = [
+        fetchPackageJsonFromJsdelivr(packageName, 'latest'),
+      ]
+
+      if (majorVersion) {
+        requests.push(fetchPackageJsonFromJsdelivr(packageName, majorVersion))
+      }
+
+      // Execute all requests simultaneously
+      const results = await Promise.all(requests)
+
+      const latestResult = results[0]
+      const majorResult = results[1]
+
+      if (!latestResult) {
+        // Package not on jsDelivr, mark for npm fallback
+        failedPackages.push(packageName)
+        return
+      }
+
+      const latestVersion = latestResult.version
+      const allVersions = [latestVersion]
+
+      // Add the major version result if different from latest
+      if (majorResult && majorResult.version !== latestVersion) {
+        allVersions.push(majorResult.version)
+      }
+
+      const result = {
+        latestVersion,
+        allVersions: allVersions.sort(semver.rcompare),
+      }
+
+      // Cache the result
+      packageCache.set(packageName, {
+        data: result,
+        timestamp: Date.now(),
+      })
+
+      packageData.set(packageName, result)
+      completedCount++
+
+      if (onProgress) {
+        onProgress(packageName, completedCount, total)
+      }
+    } catch (error) {
+      // On error, mark for npm fallback
+      failedPackages.push(packageName)
     }
   })
 
-  // Wait for all requests to complete
+  // Wait for all jsDelivr requests to complete
   await Promise.all(allPromises)
+
+  // Batch fetch all failed packages from npm registry in one call
+  if (failedPackages.length > 0) {
+    const npmData = await getAllPackageData(failedPackages, (pkg, completed, npmTotal) => {
+      completedCount++
+      if (onProgress) {
+        onProgress(pkg, completedCount, total)
+      }
+    })
+
+    // Merge npm data into results and cache it
+    for (const [packageName, data] of npmData.entries()) {
+      packageData.set(packageName, data)
+      packageCache.set(packageName, {
+        data,
+        timestamp: Date.now(),
+      })
+    }
+  }
 
   // Clear the progress line and show completion time if no custom progress handler
   if (!onProgress) {


### PR DESCRIPTION
Instead of falling back to npm registry individually for each package not found on jsDelivr, collect all failed packages and fetch them in a single batch call. This reduces the number of API calls and improves overall performance when multiple packages need fallback.