### PR TITLE
feat/inup-ignore

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,1 +1,2 @@
 export * from './constants'
+export * from './project-config'

--- a/src/config/project-config.ts
+++ b/src/config/project-config.ts
@@ -1,0 +1,109 @@
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+
+/**
+ * Project-level configuration loaded from .inuprc or .inuprc.json
+ */
+export interface InupProjectConfig {
+  /**
+   * Packages to ignore during upgrade checks.
+   * Supports exact names and glob patterns (e.g., "@babel/*", "eslint-*")
+   */
+  ignore?: string[]
+
+  /**
+   * Exclude directory patterns (regex patterns)
+   */
+  exclude?: string[]
+}
+
+const CONFIG_FILES = ['.inuprc', '.inuprc.json', 'inup.config.json']
+
+/**
+ * Load project configuration from .inuprc, .inuprc.json, or inup.config.json
+ * Searches in the specified directory and parent directories up to root
+ */
+export function loadProjectConfig(cwd: string): InupProjectConfig {
+  let currentDir = cwd
+
+  while (currentDir !== '/') {
+    for (const configFile of CONFIG_FILES) {
+      const configPath = join(currentDir, configFile)
+      if (existsSync(configPath)) {
+        try {
+          const content = readFileSync(configPath, 'utf-8')
+          const config = JSON.parse(content) as InupProjectConfig
+          return normalizeConfig(config)
+        } catch (error) {
+          // Invalid JSON or read error - continue searching
+          console.warn(`Warning: Failed to parse ${configPath}: ${error}`)
+        }
+      }
+    }
+
+    // Move to parent directory
+    const parentDir = join(currentDir, '..')
+    if (parentDir === currentDir) break
+    currentDir = parentDir
+  }
+
+  return {}
+}
+
+/**
+ * Normalize and validate the config
+ */
+function normalizeConfig(config: InupProjectConfig): InupProjectConfig {
+  const normalized: InupProjectConfig = {}
+
+  if (config.ignore) {
+    if (Array.isArray(config.ignore)) {
+      normalized.ignore = config.ignore.filter((item) => typeof item === 'string')
+    }
+  }
+
+  if (config.exclude) {
+    if (Array.isArray(config.exclude)) {
+      normalized.exclude = config.exclude.filter((item) => typeof item === 'string')
+    }
+  }
+
+  return normalized
+}
+
+/**
+ * Check if a package name matches any of the ignore patterns
+ * Supports exact matches and glob patterns (* and ?)
+ */
+export function isPackageIgnored(packageName: string, ignorePatterns: string[]): boolean {
+  for (const pattern of ignorePatterns) {
+    if (matchesPattern(packageName, pattern)) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Match a package name against a pattern
+ * Supports:
+ * - Exact match: "lodash"
+ * - Wildcard: "*" matches any sequence of characters
+ * - Single char wildcard: "?" matches single character
+ * - Scoped packages: "@babel/*" matches all @babel packages
+ */
+function matchesPattern(name: string, pattern: string): boolean {
+  // Exact match
+  if (pattern === name) {
+    return true
+  }
+
+  // Convert glob pattern to regex
+  const regexPattern = pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&') // Escape special regex chars except * and ?
+    .replace(/\*/g, '.*') // * matches any sequence
+    .replace(/\?/g, '.') // ? matches single char
+
+  const regex = new RegExp(`^${regexPattern}$`)
+  return regex.test(name)
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,7 @@ export interface UpgradeOptions {
   cwd?: string
   excludePatterns?: string[]
   packageManager?: PackageManager // Manual override for package manager
+  ignorePackages?: string[] // Package names/patterns to ignore (from .inuprc or --ignore flag)
 }
 
 export interface PackageJson {

--- a/test/unit/config/project-config.test.ts
+++ b/test/unit/config/project-config.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdirSync, writeFileSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { loadProjectConfig, isPackageIgnored } from '../../../src/config/project-config'
+
+describe('project-config', () => {
+  let testDir: string
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `inup-test-${Date.now()}`)
+    mkdirSync(testDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  describe('loadProjectConfig()', () => {
+    it('should return empty config when no config file exists', () => {
+      const config = loadProjectConfig(testDir)
+      expect(config).toEqual({})
+    })
+
+    it('should load config from .inuprc', () => {
+      const configContent = {
+        ignore: ['lodash', 'moment'],
+      }
+      writeFileSync(join(testDir, '.inuprc'), JSON.stringify(configContent))
+
+      const config = loadProjectConfig(testDir)
+      expect(config.ignore).toEqual(['lodash', 'moment'])
+    })
+
+    it('should load config from .inuprc.json', () => {
+      const configContent = {
+        ignore: ['react', 'react-dom'],
+      }
+      writeFileSync(join(testDir, '.inuprc.json'), JSON.stringify(configContent))
+
+      const config = loadProjectConfig(testDir)
+      expect(config.ignore).toEqual(['react', 'react-dom'])
+    })
+
+    it('should load config from inup.config.json', () => {
+      const configContent = {
+        ignore: ['typescript'],
+        exclude: ['dist', 'node_modules'],
+      }
+      writeFileSync(join(testDir, 'inup.config.json'), JSON.stringify(configContent))
+
+      const config = loadProjectConfig(testDir)
+      expect(config.ignore).toEqual(['typescript'])
+      expect(config.exclude).toEqual(['dist', 'node_modules'])
+    })
+
+    it('should prefer .inuprc over other config files', () => {
+      writeFileSync(join(testDir, '.inuprc'), JSON.stringify({ ignore: ['from-inuprc'] }))
+      writeFileSync(join(testDir, '.inuprc.json'), JSON.stringify({ ignore: ['from-inuprc-json'] }))
+      writeFileSync(
+        join(testDir, 'inup.config.json'),
+        JSON.stringify({ ignore: ['from-inup-config'] })
+      )
+
+      const config = loadProjectConfig(testDir)
+      expect(config.ignore).toEqual(['from-inuprc'])
+    })
+
+    it('should search parent directories for config', () => {
+      const subDir = join(testDir, 'packages', 'my-package')
+      mkdirSync(subDir, { recursive: true })
+
+      writeFileSync(join(testDir, '.inuprc'), JSON.stringify({ ignore: ['parent-config'] }))
+
+      const config = loadProjectConfig(subDir)
+      expect(config.ignore).toEqual(['parent-config'])
+    })
+
+    it('should handle invalid JSON gracefully', () => {
+      writeFileSync(join(testDir, '.inuprc'), 'not valid json {')
+
+      const config = loadProjectConfig(testDir)
+      expect(config).toEqual({})
+    })
+
+    it('should filter out non-string values in ignore array', () => {
+      const configContent = {
+        ignore: ['valid', 123, 'also-valid', null, 'still-valid'],
+      }
+      writeFileSync(join(testDir, '.inuprc'), JSON.stringify(configContent))
+
+      const config = loadProjectConfig(testDir)
+      expect(config.ignore).toEqual(['valid', 'also-valid', 'still-valid'])
+    })
+  })
+
+  describe('isPackageIgnored()', () => {
+    it('should match exact package names', () => {
+      expect(isPackageIgnored('lodash', ['lodash'])).toBe(true)
+      expect(isPackageIgnored('lodash', ['moment'])).toBe(false)
+    })
+
+    it('should match wildcard patterns with *', () => {
+      expect(isPackageIgnored('@babel/core', ['@babel/*'])).toBe(true)
+      expect(isPackageIgnored('@babel/preset-env', ['@babel/*'])).toBe(true)
+      expect(isPackageIgnored('@types/node', ['@babel/*'])).toBe(false)
+    })
+
+    it('should match prefix patterns', () => {
+      expect(isPackageIgnored('eslint-plugin-react', ['eslint-*'])).toBe(true)
+      expect(isPackageIgnored('eslint-config-prettier', ['eslint-*'])).toBe(true)
+      expect(isPackageIgnored('prettier', ['eslint-*'])).toBe(false)
+    })
+
+    it('should match suffix patterns', () => {
+      expect(isPackageIgnored('react-dom', ['*-dom'])).toBe(true)
+      expect(isPackageIgnored('preact-dom', ['*-dom'])).toBe(true)
+      expect(isPackageIgnored('react', ['*-dom'])).toBe(false)
+    })
+
+    it('should match single character wildcard with ?', () => {
+      expect(isPackageIgnored('lodash', ['lodas?'])).toBe(true)
+      expect(isPackageIgnored('lodash', ['lod???'])).toBe(true)
+      expect(isPackageIgnored('lodash', ['lod??'])).toBe(false)
+    })
+
+    it('should match multiple patterns', () => {
+      const patterns = ['lodash', '@babel/*', 'eslint-*']
+      expect(isPackageIgnored('lodash', patterns)).toBe(true)
+      expect(isPackageIgnored('@babel/core', patterns)).toBe(true)
+      expect(isPackageIgnored('eslint-plugin-react', patterns)).toBe(true)
+      expect(isPackageIgnored('react', patterns)).toBe(false)
+    })
+
+    it('should return false for empty patterns array', () => {
+      expect(isPackageIgnored('lodash', [])).toBe(false)
+    })
+
+    it('should handle scoped packages correctly', () => {
+      expect(isPackageIgnored('@types/node', ['@types/*'])).toBe(true)
+      expect(isPackageIgnored('@types/react', ['@types/react'])).toBe(true)
+      expect(isPackageIgnored('@types/react-dom', ['@types/react'])).toBe(false)
+      expect(isPackageIgnored('@types/react-dom', ['@types/react*'])).toBe(true)
+    })
+
+    it('should escape special regex characters in patterns', () => {
+      // The dot in package names should be treated literally
+      expect(isPackageIgnored('socket.io', ['socket.io'])).toBe(true)
+      expect(isPackageIgnored('socketXio', ['socket.io'])).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
Add ability to ignore specific packages during upgrade checks via project configuration files (.inuprc, .inuprc.json, inup.config.json) or CLI --ignore flag.

Supports exact package names and glob patterns like @babel/*, eslint-*, and wildcards (*, ?). CLI options merge with project config, allowing flexible package exclusion strategies.