### PR TITLE
fix/tests-of-jsdeliver-missing-fallback 

### DIFF
--- a/src/services/jsdelivr-registry.ts
+++ b/src/services/jsdelivr-registry.ts
@@ -367,7 +367,11 @@ async function fetchPackageManifestFromNpmRegistry(
 
     return (await response.json()) as Record<string, unknown>
   } catch (error) {
-    debugLog.warn('npm-registry', `exact manifest fallback failed for ${packageName}@${version}`, error)
+    debugLog.warn(
+      'npm-registry',
+      `exact manifest fallback failed for ${packageName}@${version}`,
+      error
+    )
     return null
   } finally {
     clearTimeout(timeoutId)

--- a/src/services/jsdelivr-registry.ts
+++ b/src/services/jsdelivr-registry.ts
@@ -7,6 +7,8 @@ import {
   JSDELIVR_POOL_TIMEOUT,
   JSDELIVR_RETRY_TIMEOUTS,
   JSDELIVR_RETRY_DELAYS,
+  NPM_REGISTRY_URL,
+  REQUEST_TIMEOUT,
 } from '../config'
 import { debugLog } from '../utils'
 
@@ -340,6 +342,38 @@ async function fetchPackageManifestFromJsdelivr(
   return null
 }
 
+async function fetchPackageManifestFromNpmRegistry(
+  packageName: string,
+  version: string
+): Promise<Record<string, unknown> | null> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT)
+
+  try {
+    const response = await fetch(
+      `${NPM_REGISTRY_URL}/${encodeURIComponent(packageName)}/${encodeURIComponent(version)}`,
+      {
+        method: 'GET',
+        headers: {
+          accept: 'application/json',
+        },
+        signal: controller.signal,
+      }
+    )
+
+    if (!response.ok) {
+      return null
+    }
+
+    return (await response.json()) as Record<string, unknown>
+  } catch (error) {
+    debugLog.warn('npm-registry', `exact manifest fallback failed for ${packageName}@${version}`, error)
+    return null
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
 const inFlightManifests = new Map<string, Promise<Record<string, unknown> | null>>()
 
 export async function fetchExactPackageManifest(
@@ -358,11 +392,16 @@ export async function fetchExactPackageManifest(
     return await inFlight
   }
 
-  const lookupPromise = fetchPackageManifestFromJsdelivr(packageName, normalizedVersion).finally(
-    () => {
-      inFlightManifests.delete(cacheKey)
+  const lookupPromise = (async () => {
+    const jsdelivrManifest = await fetchPackageManifestFromJsdelivr(packageName, normalizedVersion)
+    if (jsdelivrManifest) {
+      return jsdelivrManifest
     }
-  )
+
+    return await fetchPackageManifestFromNpmRegistry(packageName, normalizedVersion)
+  })().finally(() => {
+    inFlightManifests.delete(cacheKey)
+  })
   inFlightManifests.set(cacheKey, lookupPromise)
   return await lookupPromise
 }
@@ -456,4 +495,8 @@ export async function getAllPackageDataFromJsdelivr(
  */
 export async function closeJsdelivrPool(): Promise<void> {
   await jsdelivrPool.close()
+}
+
+export function clearExactManifestCache(): void {
+  inFlightManifests.clear()
 }

--- a/test/integration/services.test.ts
+++ b/test/integration/services.test.ts
@@ -1,16 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { readFileSync } from 'fs'
-import { join } from 'path'
 import { ChangelogFetcher } from '../../src/services/changelog-fetcher'
 import { getAllPackageData } from '../../src/services/npm-registry'
 import { fetchExactPackageManifest } from '../../src/services/jsdelivr-registry'
 import { PACKAGE_NAME } from '../../src/config/constants'
 
 describe('Services Integration Tests', () => {
-  const packageVersion = JSON.parse(
-    readFileSync(join(process.cwd(), 'package.json'), 'utf-8')
-  ).version as string
-
   describe(`ChangelogFetcher with ${PACKAGE_NAME}`, () => {
     let fetcher: ChangelogFetcher
 
@@ -20,6 +14,9 @@ describe('Services Integration Tests', () => {
     })
 
     it(`should fetch metadata for ${PACKAGE_NAME}`, async () => {
+      const packageVersion = (await getAllPackageData([PACKAGE_NAME])).get(PACKAGE_NAME)?.latestVersion ?? ''
+
+      expect(packageVersion).toMatch(/^\d+\.\d+\.\d+$/)
       const metadata = await fetcher.fetchPackageMetadata(PACKAGE_NAME, packageVersion)
 
       expect(metadata).not.toBeNull()
@@ -37,6 +34,8 @@ describe('Services Integration Tests', () => {
     }, 10000)
 
     it('should use cache on second fetch', async () => {
+      const packageVersion = (await getAllPackageData([PACKAGE_NAME])).get(PACKAGE_NAME)?.latestVersion ?? ''
+
       const start1 = Date.now()
       await fetcher.fetchPackageMetadata('inup', packageVersion)
       const duration1 = Date.now() - start1
@@ -93,6 +92,9 @@ describe('Services Integration Tests', () => {
 
   describe(`jsdelivr exact manifest with ${PACKAGE_NAME}`, () => {
     it(`should fetch exact package manifest for ${PACKAGE_NAME}`, async () => {
+      const packageVersion = (await getAllPackageData([PACKAGE_NAME])).get(PACKAGE_NAME)?.latestVersion ?? ''
+
+      expect(packageVersion).toMatch(/^\d+\.\d+\.\d+$/)
       const manifest = await fetchExactPackageManifest(PACKAGE_NAME, packageVersion)
 
       expect(manifest).not.toBeNull()

--- a/test/unit/services/jsdelivr-registry.retries.test.ts
+++ b/test/unit/services/jsdelivr-registry.retries.test.ts
@@ -22,7 +22,7 @@ vi.mock('../../../src/config', async () => {
   }
 })
 
-const { fetchExactPackageManifest } = await import('../../../src/services/jsdelivr-registry')
+const { fetchExactPackageManifest, clearExactManifestCache } = await import('../../../src/services/jsdelivr-registry')
 const { JSDELIVR_RETRY_TIMEOUTS } = await import('../../../src/config')
 
 const createTimeoutError = () => {
@@ -37,6 +37,15 @@ describe('jsdelivr-registry retries', () => {
     requestMock.mockReset()
     closeMock.mockReset()
     PoolMock.mockClear()
+    clearExactManifestCache()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({}),
+      })
+    )
   })
 
   it('retries jsDelivr exact-manifest request and succeeds', async () => {

--- a/test/unit/services/jsdelivr-registry.test.ts
+++ b/test/unit/services/jsdelivr-registry.test.ts
@@ -1,15 +1,13 @@
 import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'fs'
-import { join } from 'path'
 import { fetchExactPackageManifest } from '../../../src/services/jsdelivr-registry'
+import { getAllPackageData } from '../../../src/services/npm-registry'
 import { PACKAGE_NAME } from '../../../src/config/constants'
 
 describe('jsdelivr-registry', () => {
-  const packageVersion = JSON.parse(
-    readFileSync(join(process.cwd(), 'package.json'), 'utf-8')
-  ).version as string
-
   it('fetches an exact pinned package manifest from jsdelivr', async () => {
+    const packageVersion = (await getAllPackageData([PACKAGE_NAME])).get(PACKAGE_NAME)?.latestVersion ?? ''
+
+    expect(packageVersion).toMatch(/^\d+\.\d+\.\d+$/)
     const manifest = await fetchExactPackageManifest(PACKAGE_NAME, packageVersion)
 
     expect(manifest).not.toBeNull()


### PR DESCRIPTION
…fetching

Adds a fallback to the npm registry when jsdelivr doesn't have the exact package manifest available. Also improves tests by removing hardcoded package version dependencies.