### PR TITLE
feat/cli-quick-wins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  # Dogfooding: inup is a dependency upgrader, so it should keep itself current.
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      # Batch low-risk dev tooling into a single PR to cut noise.
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Audit dependencies
+        run: pnpm audit --audit-level=high
+
       - name: Check formatting
         run: pnpm format:check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Audit dependencies
-        run: pnpm audit --audit-level=high
-
       - name: Check formatting
         run: pnpm format:check
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,7 @@ import { UpgradeRunner } from './index'
 import { checkForUpdateAsync } from './services'
 import { loadProjectConfig, PACKAGE_NAME, PACKAGE_VERSION } from './config'
 import { PackageManager } from './types'
-import { enableDebugLogging } from './utils'
+import { enableDebugLogging, applyColorSetting } from './utils'
 import { getGitWorkingTreeState } from './utils/git'
 import { TerminalInput } from './ui'
 
@@ -20,9 +20,14 @@ export interface CliOptions {
   maxDepth: string
   packageManager?: string
   debug?: boolean
+  color?: boolean
+  saveExact?: boolean
 }
 
 export async function runCli(options: CliOptions): Promise<void> {
+  // Resolve colored-output intent before anything renders.
+  applyColorSetting(options.color)
+
   const cwd = resolve(options.dir)
 
   if (options.debug || process.env.INUP_DEBUG === '1') {
@@ -95,6 +100,7 @@ export async function runCli(options: CliOptions): Promise<void> {
     showOptionalDependencyVulnerabilities:
       projectConfig.showOptionalDependencyVulnerabilities ?? false,
     debug: options.debug || process.env.INUP_DEBUG === '1',
+    saveExact: options.saveExact ?? false,
   })
   await upgrader.run()
 
@@ -141,6 +147,8 @@ program
   .option('--max-depth <number>', 'maximum directory depth for package.json discovery', '10')
   .option('--package-manager <name>', 'manually specify package manager (npm, yarn, pnpm, bun)')
   .option('--debug', 'write verbose debug log to /tmp/inup-debug-YYYY-MM-DD.log')
+  .option('--no-color', 'disable colored output (also respects NO_COLOR / FORCE_COLOR)')
+  .option('--save-exact', 'write exact versions instead of preserving the range prefix (^/~)')
   .action(runCli)
 
 // Handle uncaught errors gracefully

--- a/src/core/upgrade-runner.ts
+++ b/src/core/upgrade-runner.ts
@@ -37,6 +37,7 @@ export class UpgradeRunner {
       showPeerDependencyVulnerabilities: options?.showPeerDependencyVulnerabilities ?? false,
       showOptionalDependencyVulnerabilities:
         options?.showOptionalDependencyVulnerabilities ?? false,
+      saveExact: options?.saveExact ?? false,
     })
     this.upgrader = new PackageUpgrader(this.packageManager)
   }

--- a/src/interactive-ui.ts
+++ b/src/interactive-ui.ts
@@ -22,7 +22,9 @@ import {
   runInteractiveSession,
 } from './ui/session'
 
-type InteractiveUIOptions = VulnerabilityDisplayOptions
+interface InteractiveUIOptions extends VulnerabilityDisplayOptions {
+  saveExact?: boolean
+}
 
 const DEFAULT_VULNERABILITY_DISPLAY_OPTIONS: Required<VulnerabilityDisplayOptions> = {
   showPeerDependencyVulnerabilities: false,
@@ -45,7 +47,8 @@ function normalizeVulnerabilityDisplayOptions(
 export class InteractiveUI {
   private renderer: UIRenderer
   private packageManager: PackageManagerInfo
-  private readonly options: Required<InteractiveUIOptions>
+  private readonly options: Required<VulnerabilityDisplayOptions>
+  private readonly saveExact: boolean
   private readonly vulnerabilityAuditController = new VulnerabilityAuditController()
   private readonly packageInfoModalController = new PackageInfoModalController()
   private refreshView?: () => void
@@ -54,6 +57,7 @@ export class InteractiveUI {
     this.renderer = new UIRenderer()
     this.packageManager = packageManager
     this.options = normalizeVulnerabilityDisplayOptions(options)
+    this.saveExact = options?.saveExact ?? false
   }
 
   public async displayPackagesTable(packages: PackageInfo[]): Promise<void> {
@@ -78,7 +82,7 @@ export class InteractiveUI {
       this.options,
       (refresh) => { this.refreshView = refresh }
     )
-    return createUpgradeChoices(selectedStates)
+    return createUpgradeChoices(selectedStates, this.saveExact)
   }
 
   public createSelectionStates(
@@ -154,7 +158,7 @@ export class InteractiveUI {
       progress,
       attachRefresh
     )
-    return createUpgradeChoices(selectedStates)
+    return createUpgradeChoices(selectedStates, this.saveExact)
   }
 
   public enqueueSecurityAudit(selectionStates: PackageSelectionState[]): void {

--- a/src/services/package-manager-detector.ts
+++ b/src/services/package-manager-detector.ts
@@ -109,6 +109,8 @@ export class PackageManagerDetector {
     const lockFileChecks = [
       { pm: PACKAGE_MANAGERS.pnpm, path: join(cwd, 'pnpm-lock.yaml') },
       { pm: PACKAGE_MANAGERS.bun, path: join(cwd, 'bun.lockb') },
+      // Bun >= 1.2 writes a text `bun.lock` instead of the binary `bun.lockb`.
+      { pm: PACKAGE_MANAGERS.bun, path: join(cwd, 'bun.lock') },
       { pm: PACKAGE_MANAGERS.yarn, path: join(cwd, 'yarn.lock') },
       { pm: PACKAGE_MANAGERS.npm, path: join(cwd, 'package-lock.json') },
     ]

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -79,6 +79,7 @@ export interface UpgradeOptions extends VulnerabilityDisplayOptions {
   packageManager?: PackageManager // Manual override for package manager
   ignorePackages?: string[] // Package names/patterns to ignore (from .inuprc or --ignore flag)
   debug?: boolean // Write verbose debug log to /tmp/inup-debug-YYYY-MM-DD.log
+  saveExact?: boolean // Write bare versions instead of preserving the range prefix (^/~)
 }
 
 export interface PackageJson {

--- a/src/ui/session/selection-state-builder.ts
+++ b/src/ui/session/selection-state-builder.ts
@@ -116,7 +116,8 @@ export function createPendingSelectionStates(
 }
 
 export function createUpgradeChoices(
-  selectedStates: PackageSelectionState[]
+  selectedStates: PackageSelectionState[],
+  saveExact: boolean = false
 ): PackageUpgradeChoice[] {
   const choices: PackageUpgradeChoice[] = []
   selectedStates
@@ -124,10 +125,10 @@ export function createUpgradeChoices(
     .forEach((state) => {
       const targetVersion =
         state.selectedOption === 'range' ? state.rangeVersion : state.latestVersion
-      const targetVersionWithPrefix = applyVersionPrefix(
-        state.currentVersionSpecifier,
-        targetVersion
-      )
+      // Preserve the original range prefix (^/~) by default; --save-exact writes the bare version.
+      const targetVersionWithPrefix = saveExact
+        ? targetVersion
+        : applyVersionPrefix(state.currentVersionSpecifier, targetVersion)
 
       const pathsToUpdate = state.packageJsonPaths || [state.packageJsonPath]
       pathsToUpdate.forEach((packageJsonPath) => {

--- a/src/ui/themes-colors.ts
+++ b/src/ui/themes-colors.ts
@@ -188,19 +188,28 @@ function hexToRgb(hex: string): { r: number; g: number; b: number } {
 }
 
 /**
- * Get ANSI escape code to set terminal background color
+ * Get ANSI escape code to set terminal background color.
+ *
+ * Returns an empty string when color output is disabled (`--no-color`/`NO_COLOR`
+ * set `chalk.level` to 0), so the TUI inherits the user's own terminal
+ * background instead of painting over it. This escape is raw (not produced by
+ * chalk), so it must be gated explicitly.
  */
 export function getTerminalBgColorCode(): string {
+  if (chalk.level === 0) {
+    return ''
+  }
   const hex = getThemeBgColor()
   const rgb = hexToRgb(hex)
   return `\x1b[48;2;${rgb.r};${rgb.g};${rgb.b}m`
 }
 
 /**
- * Get ANSI escape code to reset terminal colors
+ * Get ANSI escape code to reset terminal colors. Empty when color is disabled,
+ * so a `--no-color` run emits no escape sequences at all.
  */
 export function getTerminalResetCode(): string {
-  return '\x1b[0m'
+  return chalk.level === 0 ? '' : '\x1b[0m'
 }
 
 const BRAND_COLORS = [chalk.red, chalk.yellow, chalk.blue, chalk.magenta]

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,0 +1,43 @@
+import chalk from 'chalk'
+
+export interface ColorEnv {
+  NO_COLOR?: string
+  FORCE_COLOR?: string
+}
+
+/**
+ * Decide whether colored output should be disabled.
+ *
+ * Precedence (highest first):
+ *   1. An explicit `--no-color` flag (`colorFlag === false`) always wins.
+ *   2. `FORCE_COLOR` keeps colors on.
+ *   3. `NO_COLOR` (any non-empty value) disables them — the de-facto standard.
+ *
+ * chalk v5 already honors the env vars on its own, but the explicit flag does
+ * not flow through automatically, so we resolve the final intent here.
+ */
+export function shouldDisableColor(
+  colorFlag: boolean | undefined,
+  env: ColorEnv = process.env
+): boolean {
+  if (colorFlag === false) {
+    return true
+  }
+  if (env.FORCE_COLOR) {
+    return false
+  }
+  return Boolean(env.NO_COLOR)
+}
+
+/**
+ * Apply the resolved color intent to chalk's global level. Call once at startup
+ * before anything renders.
+ */
+export function applyColorSetting(
+  colorFlag: boolean | undefined,
+  env: ColorEnv = process.env
+): void {
+  if (shouldDisableColor(colorFlag, env)) {
+    chalk.level = 0
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,6 +7,7 @@ export * from './exec'
 export * from './git'
 export * from './version'
 export * from './debug-logger'
+export * from './color'
 
 // Re-export async functions for convenience
 export { readPackageJsonAsync, collectAllDependenciesAsync } from './filesystem'

--- a/test/unit/services/package-manager-detector.test.ts
+++ b/test/unit/services/package-manager-detector.test.ts
@@ -92,6 +92,14 @@ describe('PackageManagerDetector', () => {
       expect(result.name).toBe('bun')
     })
 
+    it('should detect bun from text bun.lock (Bun >= 1.2)', () => {
+      writeFileSync(join(testDir, 'package.json'), JSON.stringify({}))
+      writeFileSync(join(testDir, 'bun.lock'), '')
+
+      const result = PackageManagerDetector.detect(testDir)
+      expect(result.name).toBe('bun')
+    })
+
     it('should prefer packageManager field over lock files', () => {
       writeFileSync(
         join(testDir, 'package.json'),

--- a/test/unit/ui/selection-state-builder.test.ts
+++ b/test/unit/ui/selection-state-builder.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { createUpgradeChoices } from '../../../src/ui/session/selection-state-builder'
+import { PackageSelectionState } from '../../../src/types'
+
+function makeState(overrides: Partial<PackageSelectionState> = {}): PackageSelectionState {
+  return {
+    name: 'left-pad',
+    packageJsonPath: '/repo/package.json',
+    currentVersionSpecifier: '^1.2.3',
+    currentVersion: '1.2.3',
+    rangeVersion: '1.4.0',
+    latestVersion: '2.0.0',
+    selectedOption: 'latest',
+    loadState: 'ready',
+    hasRangeUpdate: true,
+    hasMajorUpdate: true,
+    type: 'dependencies',
+    ...overrides,
+  }
+}
+
+describe('createUpgradeChoices', () => {
+  it('preserves the range prefix by default', () => {
+    const choices = createUpgradeChoices([
+      makeState({ currentVersionSpecifier: '^1.2.3', selectedOption: 'latest' }),
+      makeState({ currentVersionSpecifier: '~1.2.3', selectedOption: 'range' }),
+    ])
+
+    expect(choices[0].targetVersion).toBe('^2.0.0')
+    expect(choices[1].targetVersion).toBe('~1.4.0')
+  })
+
+  it('writes bare versions when saveExact is true', () => {
+    const choices = createUpgradeChoices(
+      [
+        makeState({ currentVersionSpecifier: '^1.2.3', selectedOption: 'latest' }),
+        makeState({ currentVersionSpecifier: '~1.2.3', selectedOption: 'range' }),
+      ],
+      true
+    )
+
+    expect(choices[0].targetVersion).toBe('2.0.0')
+    expect(choices[1].targetVersion).toBe('1.4.0')
+  })
+
+  it('skips states that are not ready or not selected', () => {
+    const choices = createUpgradeChoices([
+      makeState({ selectedOption: 'none' }),
+      makeState({ loadState: 'pending' }),
+    ])
+
+    expect(choices).toHaveLength(0)
+  })
+})

--- a/test/unit/ui/themes-colors.test.ts
+++ b/test/unit/ui/themes-colors.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import chalk from 'chalk'
+import { getTerminalBgColorCode, getTerminalResetCode } from '../../../src/ui/themes-colors'
+
+describe('terminal background escapes respect color level', () => {
+  const originalLevel = chalk.level
+
+  afterEach(() => {
+    chalk.level = originalLevel
+  })
+
+  it('emits no background/reset escapes when color is disabled', () => {
+    chalk.level = 0
+    expect(getTerminalBgColorCode()).toBe('')
+    expect(getTerminalResetCode()).toBe('')
+  })
+
+  it('emits background/reset escapes when color is enabled', () => {
+    chalk.level = 3
+    expect(getTerminalBgColorCode()).toMatch(/^\x1b\[48;2;\d+;\d+;\d+m$/)
+    expect(getTerminalResetCode()).toBe('\x1b[0m')
+  })
+})

--- a/test/unit/utils/color.test.ts
+++ b/test/unit/utils/color.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { shouldDisableColor } from '../../../src/utils/color'
+
+describe('shouldDisableColor', () => {
+  it('disables color when the --no-color flag is set, regardless of env', () => {
+    expect(shouldDisableColor(false, {})).toBe(true)
+    expect(shouldDisableColor(false, { FORCE_COLOR: '1' })).toBe(true)
+  })
+
+  it('keeps color when FORCE_COLOR is set', () => {
+    expect(shouldDisableColor(undefined, { FORCE_COLOR: '1' })).toBe(false)
+    // FORCE_COLOR wins over NO_COLOR.
+    expect(shouldDisableColor(undefined, { FORCE_COLOR: '1', NO_COLOR: '1' })).toBe(false)
+  })
+
+  it('disables color when NO_COLOR is set', () => {
+    expect(shouldDisableColor(undefined, { NO_COLOR: '1' })).toBe(true)
+  })
+
+  it('keeps color by default', () => {
+    expect(shouldDisableColor(undefined, {})).toBe(false)
+    expect(shouldDisableColor(true, {})).toBe(false)
+  })
+})


### PR DESCRIPTION
- Detect Bun's text lockfile (bun.lock), not just the binary bun.lockb
- Add --no-color (also honors NO_COLOR / FORCE_COLOR) and stop emitting the raw terminal-background escape when color is disabled, so the TUI inherits the user's own terminal background
- Add --save-exact to write bare versions instead of preserving the ^/~ range prefix
- Add a Dependabot config and a `pnpm audit` step in CI (dogfooding)