### PR TITLE
chore(deps): dependency upgrades

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,10 +60,10 @@
   "devDependencies": {
     "@types/node": "^25.9.4",
     "@types/semver": "^7.7.1",
-    "@vitest/coverage-v8": "^4.1.7",
+    "@vitest/coverage-v8": "^4.1.9",
     "prettier": "^3.9.4",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.7"
+    "vitest": "^4.1.9"
   },
   "dependencies": {
     "chalk": "^5.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         specifier: ^7.7.1
         version: 7.7.1
       '@vitest/coverage-v8':
-        specifier: ^4.1.7
+        specifier: ^4.1.9
         version: 4.1.9(vitest@4.1.9)
       prettier:
         specifier: ^3.9.4
@@ -43,7 +43,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: ^4.1.7
+        specifier: ^4.1.9
         version: 4.1.9(@types/node@25.9.4)(@vitest/coverage-v8@4.1.9)(vite@7.3.1(@types/node@25.9.4))
 
 packages:


### PR DESCRIPTION
## 📦 Dependency upgrades

Scanned **12** packages — **3** unique upgrade(s) (1 with a major available, 0 with known vulnerabilities).

### ✅ Applied in this PR

- `@vitest/coverage-v8` `^4.1.7` → `4.1.9` (devDependencies)
- `vitest` `^4.1.7` → `4.1.9` (devDependencies)

### Updates

| Package | Current | → In-range | Latest | Type | Applied | Major? | Security |
|---|---|---|---|---|---|---|---|
| `@types/node` | ^25.9.4 | ^25.9.4 | 26.0.1 | devDependencies | — | ⚠️ yes | — |
| `@vitest/coverage-v8` | ^4.1.7 | 4.1.9 | 4.1.9 | devDependencies | ✅ | — | — |
| `vitest` | ^4.1.7 | 4.1.9 | 4.1.9 | devDependencies | ✅ | — | — |

### ⏭️ Major updates available (not applied)

A new **major** version exists beyond the in-range bump above. Under the default `minor` policy the major jump is **not applied** — review and bump deliberately:

- `@types/node` (current `^25.9.4`) → **26.0.1** (devDependencies)

---

🤖 Opened by [inup](https://github.com/donfear/inup). Re-runs update this same PR.
