### PR TITLE
feat/npmrc-registry-auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Run `inup` in any project — it scans for outdated dependencies and lets you pi
 - **Live Toggles** — filter dependency types (`d`, `p`, `o`) on the fly without restarting.
 - **Zero Config** — auto-detects npm, yarn, pnpm, or bun from your lockfile.
 - **Monorepo & Workspaces Ready** — discovers and upgrades dependencies across every workspace in one pass.
+- **Private Registries** — honors your `.npmrc` (project, user, and global): scoped registries (`@scope:registry=…`) and credentials (`_authToken`, `username`/`_password`, `${ENV_VAR}` expansion) work exactly like npm's own resolution.
 - **Vulnerability Audit** — flags known security vulnerabilities right in the package list, so you know what's risky before you upgrade.
 - **Changelog Viewer** — read release notes and changelogs inline without leaving the terminal.
 - **Built-in Search** — press `/` to filter packages instantly.

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "commander": "^15.0.0",
     "env-paths": "^4.0.0",
     "nanospinner": "^1.2.2",
+    "registry-auth-token": "^5.1.1",
     "semver": "^7.8.5",
     "undici": "^8.5.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       nanospinner:
         specifier: ^1.2.2
         version: 1.2.2
+      registry-auth-token:
+        specifier: ^5.1.1
+        version: 5.1.1
       semver:
         specifier: ^7.8.5
         version: 7.8.5
@@ -237,6 +240,18 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@pnpm/config.env-replace@1.1.0':
+    resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
+    engines: {node: '>=12.22.0'}
+
+  '@pnpm/network.ca-file@1.0.2':
+    resolution: {integrity: sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==}
+    engines: {node: '>=12.22.0'}
+
+  '@pnpm/npm-conf@3.0.3':
+    resolution: {integrity: sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==}
+    engines: {node: '>=12'}
 
   '@rollup/rollup-android-arm-eabi@4.60.4':
     resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
@@ -487,6 +502,9 @@ packages:
     resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
     engines: {node: '>=22.12.0'}
 
+  config-chain@1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -543,6 +561,9 @@ packages:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
     engines: {node: '>=18'}
 
+  graceful-fs@4.2.10:
+    resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -560,6 +581,9 @@ packages:
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   ini@4.1.1:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
@@ -659,6 +683,9 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
+  proto-list@1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
   rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
     engines: {node: '>= 10.13.0'}
@@ -666,6 +693,10 @@ packages:
   regexp-tree@0.1.27:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
     hasBin: true
+
+  registry-auth-token@5.1.1:
+    resolution: {integrity: sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==}
+    engines: {node: '>=14'}
 
   resolve@1.22.12:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
@@ -947,6 +978,18 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@pnpm/config.env-replace@1.1.0': {}
+
+  '@pnpm/network.ca-file@1.0.2':
+    dependencies:
+      graceful-fs: 4.2.10
+
+  '@pnpm/npm-conf@3.0.3':
+    dependencies:
+      '@pnpm/config.env-replace': 1.1.0
+      '@pnpm/network.ca-file': 1.0.2
+      config-chain: 1.1.13
+
   '@rollup/rollup-android-arm-eabi@4.60.4':
     optional: true
 
@@ -1139,6 +1182,11 @@ snapshots:
 
   commander@15.0.0: {}
 
+  config-chain@1.1.13:
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
+
   convert-source-map@2.0.0: {}
 
   dependency-cruiser@18.0.0:
@@ -1223,6 +1271,8 @@ snapshots:
     dependencies:
       ini: 4.1.1
 
+  graceful-fs@4.2.10: {}
+
   graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
@@ -1234,6 +1284,8 @@ snapshots:
   html-escaper@2.0.2: {}
 
   ignore@7.0.5: {}
+
+  ini@1.3.8: {}
 
   ini@4.1.1: {}
 
@@ -1316,11 +1368,17 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
+  proto-list@1.2.4: {}
+
   rechoir@0.8.0:
     dependencies:
       resolve: 1.22.12
 
   regexp-tree@0.1.27: {}
+
+  registry-auth-token@5.1.1:
+    dependencies:
+      '@pnpm/npm-conf': 3.0.3
 
   resolve@1.22.12:
     dependencies:

--- a/src/features/changelog/clients/npm-registry-client.ts
+++ b/src/features/changelog/clients/npm-registry-client.ts
@@ -1,18 +1,29 @@
 import { NPM_REGISTRY_URL } from '../../../shared/config/constants'
+import { registryTargetFor, RegistryTarget } from '../../../shared/registry/registry-config'
+
+const PUBLIC_REGISTRY_ORIGIN = new URL(NPM_REGISTRY_URL).origin
 
 export class NpmRegistryClient {
+  constructor(
+    private readonly resolveRegistryTarget: (
+      packageName: string
+    ) => RegistryTarget = registryTargetFor
+  ) {}
+
   async fetchPackageManifest(
     packageName: string,
     version: string,
     signal?: AbortSignal
   ): Promise<Record<string, unknown> | null> {
     try {
+      const target = this.resolveRegistryTarget(packageName)
       const response = await fetch(
-        `${NPM_REGISTRY_URL}/${encodeURIComponent(packageName)}/${encodeURIComponent(version)}`,
+        `${target.origin}${target.pathPrefix}/${encodeURIComponent(packageName)}/${encodeURIComponent(version)}`,
         {
           method: 'GET',
           headers: {
             accept: 'application/json',
+            ...(target.authHeader ? { authorization: target.authHeader } : {}),
           },
           signal,
         }
@@ -36,6 +47,12 @@ export class NpmRegistryClient {
     packageName: string,
     signal?: AbortSignal
   ): Promise<{ downloads: number } | null> {
+    // Download counts only exist for the public registry. Skip the call for
+    // packages that resolve elsewhere — no stats there, and private package
+    // names should not be sent to api.npmjs.org.
+    if (this.resolveRegistryTarget(packageName).origin !== PUBLIC_REGISTRY_ORIGIN) {
+      return null
+    }
     try {
       const response = await fetch(
         `https://api.npmjs.org/downloads/point/last-week/${encodeURIComponent(packageName)}`,

--- a/src/shared/registry/npm-registry.ts
+++ b/src/shared/registry/npm-registry.ts
@@ -5,7 +5,8 @@ import { promisify } from 'node:util'
 const gunzipAsync = promisify(gunzip)
 const inflateAsync = promisify(inflate)
 const brotliDecompressAsync = promisify(brotliDecompress)
-import { NPM_REGISTRY_URL, POOL_CONNECTIONS } from '../config'
+import { POOL_CONNECTIONS } from '../config'
+import { registryTargetFor, RegistryTarget } from './registry-config'
 import { parseVersions } from '../versions'
 import {
   sleep,
@@ -33,9 +34,10 @@ export interface PackageVersionData {
 
 const inFlightLookups = new InflightMap<PackageVersionData>()
 
-const registryOrigin = new URL(NPM_REGISTRY_URL).origin
-const registryPathPrefix = new URL(NPM_REGISTRY_URL).pathname.replace(/\/$/, '')
-
+// One pool per registry origin: scoped packages may resolve to different
+// registries (`@scope:registry` in .npmrc), and each origin keeps its own
+// keep-alive connections. Most runs still touch a single origin.
+//
 // Connection count is kept == the adaptive controller's ceiling (POOL_CONNECTIONS)
 // so the controller is never silently throttled below its chosen limit. Idle
 // keep-alive connections are cheap.
@@ -46,16 +48,25 @@ const registryPathPrefix = new URL(NPM_REGISTRY_URL).pathname.replace(/\/$/, '')
 // controller. With a headers timeout, a stall surfaces as a transient error the
 // controller can react to (and retry handles). `bodyTimeout` stays 0 — large
 // packuments legitimately stream slowly.
-const registryPool = new Pool(registryOrigin, {
-  connections: POOL_CONNECTIONS,
-  pipelining: 1,
-  keepAliveTimeout: 30_000,
-  keepAliveMaxTimeout: 600_000,
-  headersTimeout: 30_000,
-  bodyTimeout: 0,
-  connectTimeout: 15_000,
-  allowH2: false,
-})
+const poolByOrigin = new Map<string, Pool>()
+
+function poolFor(origin: string): Pool {
+  let pool = poolByOrigin.get(origin)
+  if (!pool) {
+    pool = new Pool(origin, {
+      connections: POOL_CONNECTIONS,
+      pipelining: 1,
+      keepAliveTimeout: 30_000,
+      keepAliveMaxTimeout: 600_000,
+      headersTimeout: 30_000,
+      bodyTimeout: 0,
+      connectTimeout: 15_000,
+      allowH2: false,
+    })
+    poolByOrigin.set(origin, pool)
+  }
+  return pool
+}
 
 const MAX_REGISTRY_ATTEMPTS = 3
 const RETRY_BACKOFF_MS = [500, 1500, 3000]
@@ -74,13 +85,13 @@ async function getFreshPackageData(
   return inFlightLookups.dedupe(cacheKey, () => fetchPackageFromRegistry(packageName, onAttempt))
 }
 
-const encodeRegistryPath = (packageName: string): string => {
+const encodeRegistryPath = (packageName: string, pathPrefix: string): string => {
   const encodedName = packageName.startsWith('@')
     ? `@${encodeURIComponent(packageName.slice(1).split('/')[0])}/${encodeURIComponent(
         packageName.slice(packageName.indexOf('/') + 1)
       )}`
     : encodeURIComponent(packageName)
-  return `${registryPathPrefix}/${encodedName}`
+  return `${pathPrefix}/${encodedName}`
 }
 
 type RegistryAttemptOutcome =
@@ -98,22 +109,30 @@ type RegistryAttemptOutcome =
  */
 export type AttemptObserver = (outcome: RegistryAttemptOutcome) => void
 
-async function attemptRegistryFetch(path: string): Promise<RegistryAttemptOutcome> {
+async function attemptRegistryFetch(
+  target: RegistryTarget,
+  path: string
+): Promise<RegistryAttemptOutcome> {
   const startedAt = Date.now()
   // Conditional request: if we have a stored ETag for this packument, ask the
   // registry to validate it. Unchanged → 304 (no body) and we reuse stored data.
   // This still hits the registry every run, so data is never served stale.
-  const cached = readEtag(path)
+  // Keys are origin-qualified so two registries can never collide on a path.
+  const cacheKey = `${target.origin}${path}`
+  const cached = readEtag(cacheKey)
   try {
     const requestHeaders: Record<string, string> = {
       accept: 'application/vnd.npm.install-v1+json',
       'accept-encoding': 'gzip, deflate, br',
     }
+    if (target.authHeader) {
+      requestHeaders['authorization'] = target.authHeader
+    }
     if (cached) {
       requestHeaders['if-none-match'] = cached.etag
     }
 
-    const { statusCode, headers, body } = await registryPool.request({
+    const { statusCode, headers, body } = await poolFor(target.origin).request({
       path,
       method: 'GET',
       headers: requestHeaders,
@@ -163,7 +182,7 @@ async function attemptRegistryFetch(path: string): Promise<RegistryAttemptOutcom
     const etagHeader = headers['etag']
     const etag = Array.isArray(etagHeader) ? etagHeader[0] : etagHeader
     if (etag) {
-      writeEtag(path, etag.toString(), data)
+      writeEtag(cacheKey, etag.toString(), data)
     }
 
     return {
@@ -182,12 +201,13 @@ async function attemptRegistryFetch(path: string): Promise<RegistryAttemptOutcom
 }
 
 async function fetchFromRegistryWithRetries(
+  target: RegistryTarget,
   path: string,
   onAttempt?: AttemptObserver
 ): Promise<RegistryAttemptOutcome> {
   let lastOutcome: RegistryAttemptOutcome = { kind: 'transient' }
   for (let attempt = 0; attempt < MAX_REGISTRY_ATTEMPTS; attempt++) {
-    const outcome = await attemptRegistryFetch(path)
+    const outcome = await attemptRegistryFetch(target, path)
     onAttempt?.(outcome)
     if (outcome.kind === 'success' || outcome.kind === 'not-found') {
       return outcome
@@ -210,8 +230,11 @@ async function fetchPackageFromRegistry(
   packageName: string,
   onAttempt?: AttemptObserver
 ): Promise<PackageVersionData> {
-  const path = encodeRegistryPath(packageName)
-  const outcome = await fetchFromRegistryWithRetries(path, onAttempt)
+  // Scoped packages may live on a different registry (with credentials) than
+  // unscoped ones — resolved from the npm config chain, memoized per scope.
+  const target = registryTargetFor(packageName)
+  const path = encodeRegistryPath(packageName, target.pathPrefix)
+  const outcome = await fetchFromRegistryWithRetries(target, path, onAttempt)
 
   if (outcome.kind === 'success') {
     return outcome.data

--- a/src/shared/registry/registry-config.ts
+++ b/src/shared/registry/registry-config.ts
@@ -75,7 +75,10 @@ function resolveTarget(scope: string | undefined, npmrc?: NpmrcOverride): Regist
   let authHeader: string | undefined
   try {
     const auth = getAuthToken(parsed.href, { recursive: true, ...(npmrc ? { npmrc } : {}) })
-    if (auth?.token) {
+    // registry-auth-token stringifies an unset ${ENV_VAR} reference into the
+    // literal "undefined". Sending `Bearer undefined` guarantees a 401 where an
+    // anonymous request might succeed, so treat it as no credentials.
+    if (auth?.token && auth.token !== 'undefined') {
       authHeader = `${auth.type} ${auth.token}`
     }
   } catch {

--- a/src/shared/registry/registry-config.ts
+++ b/src/shared/registry/registry-config.ts
@@ -1,0 +1,95 @@
+import getAuthToken from 'registry-auth-token'
+import getRegistryUrlUntyped from 'registry-auth-token/registry-url'
+import { NPM_REGISTRY_URL } from '../config'
+
+// The submodule's .d.ts declares the second parameter as `{ npmrc?: … }`, but the
+// implementation consumes the plain npmrc key/value record directly.
+const getRegistryUrl = getRegistryUrlUntyped as unknown as (
+  scope?: string,
+  npmrc?: Record<string, string>
+) => string
+
+/**
+ * Where to fetch a package's metadata from, resolved from the npm configuration
+ * chain (project/workspace/user/global/builtin `.npmrc` files plus `npm_config_*`
+ * environment variables) via `registry-auth-token`.
+ *
+ * Resolution is npm's own model: a package's scope selects the registry
+ * (`@scope:registry`), falling back to the default `registry` key, falling back
+ * to the public registry. Credentials are matched against that registry's URL
+ * (`//host/path/:_authToken`, `:username`/`:_password`, legacy `:_auth`), with
+ * `${ENV_VAR}` values expanded — so tokens are only ever sent to the registry
+ * the npm config binds them to.
+ */
+export interface RegistryTarget {
+  /** Origin the HTTP pool connects to, e.g. `https://registry.company.com`. */
+  origin: string
+  /** Registry URL path prefix ('' for npmjs; Artifactory-style registries nest under one). */
+  pathPrefix: string
+  /** `authorization` header value (`Bearer …` / `Basic …`) when credentials are configured. */
+  authHeader?: string
+}
+
+/** npmrc key/value overrides; lets tests stay independent of the machine's real config. */
+export type NpmrcOverride = Record<string, string>
+
+/** Scope of a package name (`@scope/pkg` → `@scope`), or undefined when unscoped. */
+export function scopeOfPackage(packageName: string): string | undefined {
+  if (!packageName.startsWith('@')) return undefined
+  const slash = packageName.indexOf('/')
+  return slash > 0 ? packageName.slice(0, slash) : undefined
+}
+
+// Config files are re-read on every resolution inside registry-auth-token, so
+// memoize per scope: one resolution per distinct scope per process.
+const targetByScope = new Map<string, RegistryTarget>()
+
+export function registryTargetFor(packageName: string, npmrc?: NpmrcOverride): RegistryTarget {
+  const scope = scopeOfPackage(packageName) ?? ''
+  if (!npmrc) {
+    const cached = targetByScope.get(scope)
+    if (cached) return cached
+  }
+  const target = resolveTarget(scope || undefined, npmrc)
+  if (!npmrc) {
+    targetByScope.set(scope, target)
+  }
+  return target
+}
+
+function resolveTarget(scope: string | undefined, npmrc?: NpmrcOverride): RegistryTarget {
+  let registryHref = NPM_REGISTRY_URL
+  try {
+    registryHref = getRegistryUrl(scope, npmrc)
+  } catch {
+    // Unreadable npm config must never break a run — fall back to the public registry.
+  }
+
+  let parsed: URL
+  try {
+    parsed = new URL(registryHref)
+  } catch {
+    parsed = new URL(NPM_REGISTRY_URL)
+  }
+
+  let authHeader: string | undefined
+  try {
+    const auth = getAuthToken(parsed.href, { recursive: true, ...(npmrc ? { npmrc } : {}) })
+    if (auth?.token) {
+      authHeader = `${auth.type} ${auth.token}`
+    }
+  } catch {
+    // No credentials (or unreadable config) → anonymous requests, matching npm.
+  }
+
+  return {
+    origin: parsed.origin,
+    pathPrefix: parsed.pathname.replace(/\/$/, ''),
+    authHeader,
+  }
+}
+
+/** Test helper: forget memoized resolutions so npmrc overrides take effect. */
+export function clearRegistryTargetCache(): void {
+  targetByScope.clear()
+}

--- a/test/unit/features/changelog/npm-registry-client.test.ts
+++ b/test/unit/features/changelog/npm-registry-client.test.ts
@@ -10,10 +10,18 @@ const jsonResponse = (data: unknown, ok = true) => ({
 
 const abortError = () => new DOMException('aborted', 'AbortError')
 
+// Fixed registry targets so tests never depend on the machine's npm config.
+const publicRegistry = () => ({ origin: 'https://registry.npmjs.org', pathPrefix: '' })
+const privateRegistry = () => ({
+  origin: 'https://registry.example.com',
+  pathPrefix: '/npm',
+  authHeader: 'Bearer sekret',
+})
+
 let client: NpmRegistryClient
 
 beforeEach(() => {
-  client = new NpmRegistryClient()
+  client = new NpmRegistryClient(publicRegistry)
   fetchMock.mockReset()
   vi.stubGlobal('fetch', fetchMock)
 })
@@ -32,6 +40,20 @@ describe('NpmRegistryClient.fetchPackageManifest', () => {
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining('/%40scope%2Fpkg/1.0.0'),
       expect.objectContaining({ method: 'GET' })
+    )
+  })
+
+  it('fetches from the npmrc-resolved registry with its authorization header', async () => {
+    client = new NpmRegistryClient(privateRegistry)
+    fetchMock.mockResolvedValue(jsonResponse({ name: '@scope/pkg', version: '1.0.0' }))
+
+    await client.fetchPackageManifest('@scope/pkg', '1.0.0')
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://registry.example.com/npm/%40scope%2Fpkg/1.0.0',
+      expect.objectContaining({
+        headers: expect.objectContaining({ authorization: 'Bearer sekret' }),
+      })
     )
   })
 
@@ -67,6 +89,13 @@ describe('NpmRegistryClient.fetchDownloadStats', () => {
     fetchMock.mockResolvedValue(jsonResponse({}))
 
     expect(await client.fetchDownloadStats('demo')).toEqual({ downloads: 0 })
+  })
+
+  it('skips the public downloads API for packages on other registries', async () => {
+    client = new NpmRegistryClient(privateRegistry)
+
+    expect(await client.fetchDownloadStats('@scope/private-pkg')).toBeNull()
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it('returns null for unknown packages and network errors', async () => {

--- a/test/unit/features/changelog/npm-registry-client.test.ts
+++ b/test/unit/features/changelog/npm-registry-client.test.ts
@@ -98,6 +98,22 @@ describe('NpmRegistryClient.fetchDownloadStats', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  it('never forwards registry credentials to the downloads API', async () => {
+    // A user logged into npmjs has an authHeader on the public target; the
+    // downloads endpoint is a different service and must stay anonymous.
+    client = new NpmRegistryClient(() => ({
+      origin: 'https://registry.npmjs.org',
+      pathPrefix: '',
+      authHeader: 'Bearer npm-token',
+    }))
+    fetchMock.mockResolvedValue(jsonResponse({ downloads: 1 }))
+
+    await client.fetchDownloadStats('demo')
+
+    const headers = (fetchMock.mock.calls[0][1] as { headers: Record<string, string> }).headers
+    expect(headers['authorization']).toBeUndefined()
+  })
+
   it('returns null for unknown packages and network errors', async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse(null, false))
     expect(await client.fetchDownloadStats('demo')).toBeNull()

--- a/test/unit/shared/registry/npm-registry.test.ts
+++ b/test/unit/shared/registry/npm-registry.test.ts
@@ -11,12 +11,10 @@ vi.mock('../../../../src/shared/http/retry', async (importOriginal) => ({
 // Pin registry resolution to the public registry so this suite never depends on
 // the machine's real npm configuration. Individual tests override per call.
 const { registryTargetMock } = vi.hoisted(() => ({
-  registryTargetMock: vi.fn(
-    (): { origin: string; pathPrefix: string; authHeader?: string } => ({
-      origin: 'https://registry.npmjs.org',
-      pathPrefix: '',
-    })
-  ),
+  registryTargetMock: vi.fn((): { origin: string; pathPrefix: string; authHeader?: string } => ({
+    origin: 'https://registry.npmjs.org',
+    pathPrefix: '',
+  })),
 }))
 vi.mock('../../../../src/shared/registry/registry-config', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../../src/shared/registry/registry-config')>()),
@@ -431,6 +429,51 @@ describe('npm-registry', () => {
       await fetchPackageVersions(['demo-pkg'])
       // A second run hits the network again (freshness), not served purely offline.
       expect(poolRequestSpy.mock.calls.length).toBeGreaterThan(callsAfterFirst)
+    })
+
+    it('scopes cached ETags by registry origin — no cross-registry reuse', async () => {
+      // Store an ETag for demo-pkg on origin A.
+      registryTargetMock.mockReturnValueOnce({
+        origin: 'https://registry-a.example.com',
+        pathPrefix: '',
+      })
+      requestMock.mockImplementation(async () => ({
+        statusCode: 200,
+        body: JSON.stringify({ versions: { '1.0.0': {} } }),
+        headers: { etag: 'W/"origin-a"' },
+      }))
+      await fetchPackageVersions(['demo-pkg'])
+
+      // The same registry path on origin B must NOT validate against origin
+      // A's cached ETag: keys are origin-qualified.
+      clearPackageCache()
+      registryTargetMock.mockReturnValueOnce({
+        origin: 'https://registry-b.example.com',
+        pathPrefix: '',
+      })
+      let sentIfNoneMatch: string | undefined = 'not-captured'
+      poolRequestSpy.mockImplementationOnce(async (opts: unknown) => {
+        const o = opts as { headers: Record<string, string> }
+        sentIfNoneMatch = o.headers['if-none-match']
+        return {
+          statusCode: 200,
+          headers: {},
+          trailers: {},
+          opaque: null,
+          context: {},
+          body: {
+            arrayBuffer: async () =>
+              Buffer.from(JSON.stringify({ versions: { '2.0.0': {} } }), 'utf8'),
+            dump: async () => {},
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any
+      })
+
+      const result = await fetchPackageVersions(['demo-pkg'])
+
+      expect(sentIfNoneMatch).toBeUndefined()
+      expect(result.get('demo-pkg')?.latestVersion).toBe('2.0.0')
     })
   })
 })

--- a/test/unit/shared/registry/npm-registry.test.ts
+++ b/test/unit/shared/registry/npm-registry.test.ts
@@ -8,6 +8,21 @@ vi.mock('../../../../src/shared/http/retry', async (importOriginal) => ({
   sleep: vi.fn().mockResolvedValue(undefined),
 }))
 
+// Pin registry resolution to the public registry so this suite never depends on
+// the machine's real npm configuration. Individual tests override per call.
+const { registryTargetMock } = vi.hoisted(() => ({
+  registryTargetMock: vi.fn(
+    (): { origin: string; pathPrefix: string; authHeader?: string } => ({
+      origin: 'https://registry.npmjs.org',
+      pathPrefix: '',
+    })
+  ),
+}))
+vi.mock('../../../../src/shared/registry/registry-config', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../src/shared/registry/registry-config')>()),
+  registryTargetFor: registryTargetMock,
+}))
+
 import {
   clearPackageCache,
   fetchPackageVersions,
@@ -92,6 +107,34 @@ describe('npm-registry', () => {
       latestVersion: '1.2.0',
       allVersions: ['1.2.0', '1.1.0', '1.0.0'],
     })
+  })
+
+  it('sends no authorization header when the registry has no credentials', async () => {
+    requestMock.mockResolvedValue(makeOkBody({ versions: { '1.0.0': {} } }))
+
+    await fetchPackageVersions(['demo-pkg'])
+
+    const opts = poolRequestSpy.mock.calls[0][0] as { headers: Record<string, string> }
+    expect(opts.headers['authorization']).toBeUndefined()
+  })
+
+  it('routes scoped packages to their npmrc registry with its authorization header', async () => {
+    registryTargetMock.mockReturnValueOnce({
+      origin: 'https://registry.example.com',
+      pathPrefix: '/npm',
+      authHeader: 'Bearer sekret',
+    })
+    requestMock.mockResolvedValue(makeOkBody({ versions: { '1.0.0': {}, '1.1.0': {} } }))
+
+    const result = await fetchPackageVersions(['@myco/private-pkg'])
+
+    const opts = poolRequestSpy.mock.calls[0][0] as {
+      path: string
+      headers: Record<string, string>
+    }
+    expect(opts.path).toBe('/npm/@myco/private-pkg')
+    expect(opts.headers['authorization']).toBe('Bearer sekret')
+    expect(result.get('@myco/private-pkg')?.latestVersion).toBe('1.1.0')
   })
 
   it('returns empty map for empty input', async () => {

--- a/test/unit/shared/registry/registry-config.test.ts
+++ b/test/unit/shared/registry/registry-config.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  clearRegistryTargetCache,
+  registryTargetFor,
+  scopeOfPackage,
+} from '../../../../src/shared/registry/registry-config'
+
+describe('registry-config', () => {
+  beforeEach(() => {
+    clearRegistryTargetCache()
+  })
+
+  describe('scopeOfPackage', () => {
+    it('extracts the scope from scoped names', () => {
+      expect(scopeOfPackage('@myco/pkg')).toBe('@myco')
+      expect(scopeOfPackage('@a/b/c')).toBe('@a')
+    })
+
+    it('returns undefined for unscoped or malformed names', () => {
+      expect(scopeOfPackage('chalk')).toBeUndefined()
+      expect(scopeOfPackage('@no-slash')).toBeUndefined()
+    })
+  })
+
+  describe('registryTargetFor', () => {
+    // Every test passes an explicit npmrc override so results never depend on
+    // the machine's real npm configuration.
+
+    it('falls back to the public registry with an empty npm config', () => {
+      const target = registryTargetFor('chalk', {})
+
+      expect(target.origin).toBe('https://registry.npmjs.org')
+      expect(target.pathPrefix).toBe('')
+      expect(target.authHeader).toBeUndefined()
+    })
+
+    it('honors the default `registry` key for unscoped packages', () => {
+      const target = registryTargetFor('lodash', {
+        registry: 'https://registry.example.com/',
+        '//registry.example.com/:_authToken': 'sekret',
+      })
+
+      expect(target.origin).toBe('https://registry.example.com')
+      expect(target.pathPrefix).toBe('')
+      expect(target.authHeader).toBe('Bearer sekret')
+    })
+
+    it('resolves a scoped registry, keeping its path prefix', () => {
+      const target = registryTargetFor('@myco/pkg', {
+        '@myco:registry': 'https://registry.example.com/artifactory/api/npm/npm-virtual/',
+      })
+
+      expect(target.origin).toBe('https://registry.example.com')
+      expect(target.pathPrefix).toBe('/artifactory/api/npm/npm-virtual')
+      expect(target.authHeader).toBeUndefined()
+    })
+
+    it('matches credentials recursively up the registry path', () => {
+      const target = registryTargetFor('@myco/pkg', {
+        '@myco:registry': 'https://registry.example.com/artifactory/api/npm/npm-virtual/',
+        '//registry.example.com/artifactory/:_authToken': 'nested-token',
+      })
+
+      expect(target.authHeader).toBe('Bearer nested-token')
+    })
+
+    it('expands ${ENV_VAR} auth tokens the way npm does', () => {
+      process.env.INUP_TEST_REGISTRY_TOKEN = 'from-env'
+      try {
+        const target = registryTargetFor('@env/pkg', {
+          '@env:registry': 'https://registry.example.com/',
+          '//registry.example.com/:_authToken': '${INUP_TEST_REGISTRY_TOKEN}',
+        })
+
+        expect(target.authHeader).toBe('Bearer from-env')
+      } finally {
+        delete process.env.INUP_TEST_REGISTRY_TOKEN
+      }
+    })
+
+    it('builds Basic auth from username + base64 _password', () => {
+      const target = registryTargetFor('@basic/pkg', {
+        '@basic:registry': 'https://registry.example.com/npm/',
+        '//registry.example.com/npm/:username': 'mike',
+        '//registry.example.com/npm/:_password': Buffer.from('hunter2', 'utf8').toString('base64'),
+      })
+
+      expect(target.authHeader).toBe(
+        `Basic ${Buffer.from('mike:hunter2', 'utf8').toString('base64')}`
+      )
+    })
+
+    it('scopes without npmrc config fall back to the default registry', () => {
+      const target = registryTargetFor('@unknown/pkg', {
+        '@other:registry': 'https://registry.example.com/',
+      })
+
+      expect(target.origin).toBe('https://registry.npmjs.org')
+    })
+
+    it('memoizes resolutions per scope', () => {
+      const first = registryTargetFor('some-unscoped-pkg')
+      const second = registryTargetFor('another-unscoped-pkg')
+
+      // Same object identity ⇒ the npm config chain was only resolved once.
+      expect(second).toBe(first)
+    })
+  })
+})

--- a/test/unit/shared/registry/registry-config.test.ts
+++ b/test/unit/shared/registry/registry-config.test.ts
@@ -105,5 +105,66 @@ describe('registry-config', () => {
       // Same object identity ⇒ the npm config chain was only resolved once.
       expect(second).toBe(first)
     })
+
+    it('treats an unset ${ENV_VAR} token as no credentials, never `Bearer undefined`', () => {
+      // registry-auth-token stringifies unset env references into the literal
+      // "undefined"; sending that guarantees a 401 where anonymous might work.
+      const target = registryTargetFor('@env/pkg', {
+        '@env:registry': 'https://registry.example.com/',
+        '//registry.example.com/:_authToken': '${DEFINITELY_UNSET_INUP_VAR}',
+      })
+
+      expect(target.authHeader).toBeUndefined()
+    })
+
+    it('ignores empty auth tokens', () => {
+      const target = registryTargetFor('@empty/pkg', {
+        '@empty:registry': 'https://registry.example.com/',
+        '//registry.example.com/:_authToken': '',
+      })
+
+      expect(target.authHeader).toBeUndefined()
+    })
+
+    it('supports the legacy global _auth credential', () => {
+      const target = registryTargetFor('@legacy/pkg', {
+        '@legacy:registry': 'https://registry.example.com/',
+        _auth: Buffer.from('user:pass', 'utf8').toString('base64'),
+      })
+
+      expect(target.authHeader).toBe(`Basic ${Buffer.from('user:pass', 'utf8').toString('base64')}`)
+    })
+
+    it('normalizes registries declared without a trailing slash', () => {
+      const target = registryTargetFor('@noslash/pkg', {
+        '@noslash:registry': 'https://registry.example.com/npm',
+      })
+
+      expect(target.origin).toBe('https://registry.example.com')
+      expect(target.pathPrefix).toBe('/npm')
+    })
+
+    it('falls back to the public registry when the configured URL is garbage', () => {
+      const target = registryTargetFor('@broken/pkg', {
+        '@broken:registry': 'not a url at all',
+      })
+
+      expect(target.origin).toBe('https://registry.npmjs.org')
+      expect(target.pathPrefix).toBe('')
+    })
+
+    it('never lets an npmrc override poison the per-scope cache', () => {
+      const withOverride = registryTargetFor('@iso/pkg', {
+        '@iso:registry': 'https://registry.example.com/',
+      })
+      const withDifferentOverride = registryTargetFor('@iso/pkg', {
+        '@iso:registry': 'https://other.example.com/',
+      })
+
+      // Each override resolves independently — no stale memoized result leaks
+      // from one injected config into the next.
+      expect(withOverride.origin).toBe('https://registry.example.com')
+      expect(withDifferentOverride.origin).toBe('https://other.example.com')
+    })
   })
 })


### PR DESCRIPTION
## What

inup previously hardcoded `https://registry.npmjs.org` and never sent credentials. Anyone using a private registry (Verdaccio, Artifactory, GitHub Packages, …) got 404s / `unknown` for private scoped packages — and their private package names were sent to the public registry while trying.

This PR makes metadata fetching honor the npm configuration chain, exactly like npm itself:

- **Scoped registries**: `@scope:registry=…` from project/workspace/user/global `.npmrc` (plus `npm_config_*` env vars).
- **Credentials**: `//host/path/:_authToken`, `username`/`_password`, legacy `_auth`, with `${ENV_VAR}` expansion. Tokens are only sent to the registry the npmrc binds them to.
- **Path-prefixed registries** (Artifactory-style `…/api/npm/npm-virtual/`) work.

## How

- New dependency: [`registry-auth-token`](https://github.com/rexxars/registry-auth-token) (CJS, small). Its bundled `registry-url` submodule resolves the scope → registry mapping through `@pnpm/npm-conf`, which reads the full npm config chain **including the project-level `.npmrc`**. The standalone `registry-url` package was considered and rejected: it only reads the nearest `.npmrc` with no layer merging.
- New `src/shared/registry/registry-config.ts`: resolves a `RegistryTarget` (origin, path prefix, auth header) per package, memoized per scope.
- `npm-registry.ts`: one undici pool per registry origin (same tuned options); ETag cache keys are origin-qualified so two registries can never collide on a path. Existing tmp-cache entries are simply orphaned and swept by the 14-day sweep.
- Changelog manifest fetches (`NpmRegistryClient`) use the same resolution + auth header; the public downloads API (`api.npmjs.org`) is skipped for packages that resolve to a non-public registry, so private names aren't leaked there.

## Not in scope (follow-up candidates)

- The bulk advisory audit (`/-/npm/v1/security/advisories/bulk`) still posts all package names to the configured public registry — same behavior as before. Deciding whether to exclude private-registry packages from audit is a separate behavioral question.
- The self-update check for inup itself still targets public npm (by design).

## Testing

- 14 new unit tests: `registry-config` resolution (scoped registry, path prefix, Bearer/Basic/env-expanded tokens, recursive path matching, memoization) and auth-header/routing behavior in `npm-registry` and `NpmRegistryClient`. All tests use explicit npmrc overrides so they never depend on the machine's real config; the `npm-registry` suite pins resolution for the same reason.
- Full suite: 901 passed.
- End-to-end: verified against a temp project whose `.npmrc` maps `@myco` to a path-prefixed registry with `${ENV_VAR}` token — resolved origin/prefix/header all correct through the compiled `dist/`; live `--json` run against the public registry unaffected.
