### PR TITLE
chore/hardening-quick-wins

### DIFF
--- a/src/features/changelog/clients/github-client.ts
+++ b/src/features/changelog/clients/github-client.ts
@@ -4,6 +4,24 @@ import { PACKAGE_NAME } from '../../../shared/config'
 
 const GITHUB_RELEASES_PAGE_LIMIT = 3
 
+/**
+ * Headers for api.github.com requests. Honors an ambient token (GitHub Actions
+ * sets GITHUB_TOKEN, gh CLI users often export GH_TOKEN): authenticated requests
+ * get 5,000 req/hr instead of the 60 req/hr anonymous limit, which large upgrade
+ * sessions can exhaust while fetching release notes.
+ */
+function githubApiHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    accept: 'application/vnd.github.v3+json',
+    'user-agent': `${PACKAGE_NAME}-cli`,
+  }
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN
+  if (token) {
+    headers['authorization'] = `Bearer ${token}`
+  }
+  return headers
+}
+
 export class GitHubClient {
   private releasesCache = new Map<string, GitHubRelease[] | null>()
   private rawChangelogCache = new Map<string, string | null>()
@@ -26,10 +44,7 @@ export class GitHubClient {
         `https://api.github.com/repos/${repo.owner}/${repo.repo}/releases/tags/${tag}`,
         {
           method: 'GET',
-          headers: {
-            accept: 'application/vnd.github.v3+json',
-            'user-agent': `${PACKAGE_NAME}-cli`,
-          },
+          headers: githubApiHeaders(),
           signal,
         }
       )
@@ -93,10 +108,7 @@ export class GitHubClient {
           `https://api.github.com/repos/${repo.owner}/${repo.repo}/releases?per_page=100&page=${page}`,
           {
             method: 'GET',
-            headers: {
-              accept: 'application/vnd.github.v3+json',
-              'user-agent': `${PACKAGE_NAME}-cli`,
-            },
+            headers: githubApiHeaders(),
             signal,
           }
         )

--- a/src/features/changelog/clients/github-client.ts
+++ b/src/features/changelog/clients/github-client.ts
@@ -22,6 +22,22 @@ function githubApiHeaders(): Record<string, string> {
   return headers
 }
 
+/**
+ * GET an api.github.com URL, retrying anonymously when the ambient token is
+ * rejected (401). A stale/revoked GITHUB_TOKEN sitting in the environment must
+ * never make release notes *worse* than having no token at all — public-repo
+ * requests that used to succeed anonymously keep succeeding.
+ */
+async function fetchGitHubApi(url: string, signal: AbortSignal): Promise<Response> {
+  const headers = githubApiHeaders()
+  const response = await fetch(url, { method: 'GET', headers, signal })
+  if (response.status === 401 && headers['authorization']) {
+    const { authorization: _rejected, ...anonymousHeaders } = headers
+    return fetch(url, { method: 'GET', headers: anonymousHeaders, signal })
+  }
+  return response
+}
+
 export class GitHubClient {
   private releasesCache = new Map<string, GitHubRelease[] | null>()
   private rawChangelogCache = new Map<string, string | null>()
@@ -40,13 +56,9 @@ export class GitHubClient {
     if (!repo) return null
 
     try {
-      const response = await fetch(
+      const response = await fetchGitHubApi(
         `https://api.github.com/repos/${repo.owner}/${repo.repo}/releases/tags/${tag}`,
-        {
-          method: 'GET',
-          headers: githubApiHeaders(),
-          signal,
-        }
+        signal
       )
 
       if (!response.ok) return null
@@ -104,13 +116,9 @@ export class GitHubClient {
 
     for (let page = 1; page <= GITHUB_RELEASES_PAGE_LIMIT; page += 1) {
       try {
-        const response = await fetch(
+        const response = await fetchGitHubApi(
           `https://api.github.com/repos/${repo.owner}/${repo.repo}/releases?per_page=100&page=${page}`,
-          {
-            method: 'GET',
-            headers: githubApiHeaders(),
-            signal,
-          }
+          signal
         )
 
         if (!response.ok) break

--- a/src/shared/http/etag-store.ts
+++ b/src/shared/http/etag-store.ts
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  rmSync,
   statSync,
   unlinkSync,
   writeFileSync,
@@ -44,26 +45,50 @@ const MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000 // 14 days
 
 let enabled = true
 let sweptThisProcess = false
+let cacheRootOverride: string | null = null
+let resolvedSchemaDir: string | null = null
 
 /** Allow tests/callers to toggle the store without touching call sites. */
 export function setEtagCacheEnabled(value: boolean): void {
   enabled = value
 }
 
-/** Resolve (and lazily create) the cache directory, sweeping stale entries once. */
-function cacheDir(): string {
+/**
+ * Test hook: point the store at an isolated root instead of the user's real
+ * cache directory (null restores the default). Tests must never wipe or race
+ * on the persistent per-user cache.
+ */
+export function setEtagCacheRoot(root: string | null): void {
+  cacheRootOverride = root
+  resolvedSchemaDir = null
+  sweptThisProcess = false
+}
+
+/** The root holding one subdirectory per schema generation. */
+function cacheRoot(): string {
   // Version data is not project-specific, so it lives in the per-user cache
   // directory (env-paths, like the config dir), shared across every project the
   // user scans. It used to live in the OS temp dir, but macOS clears that on
   // reboot and Linux distros sweep it periodically — throwing the cache away
   // exactly when it is most useful.
-  const dir = join(envPaths(PACKAGE_NAME).cache, 'etag-cache', SCHEMA)
+  return cacheRootOverride ?? join(envPaths(PACKAGE_NAME).cache, 'etag-cache')
+}
+
+/** Resolve (and lazily create) the cache directory, sweeping stale entries once. */
+function cacheDir(): string {
+  if (resolvedSchemaDir === null) {
+    // The location is process-invariant; derive it once instead of running
+    // env-paths on every cache read/write of the registry hot path.
+    resolvedSchemaDir = join(cacheRoot(), SCHEMA)
+  }
+  const dir = resolvedSchemaDir
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true })
   }
   if (!sweptThisProcess) {
     sweptThisProcess = true
     sweepStale(dir)
+    sweepOldGenerations(cacheRoot())
   }
   return dir
 }
@@ -78,6 +103,26 @@ function sweepStale(dir: string): void {
         if (statSync(file).mtimeMs < cutoff) unlinkSync(file)
       } catch {
         /* skip files we can't stat/remove */
+      }
+    }
+  } catch {
+    /* sweeping is optional; never fail a run over it */
+  }
+}
+
+/**
+ * Remove schema generations other than the active one. The cache directory is
+ * persistent (unlike the old tmpdir location, which the OS reclaimed), so after
+ * a SCHEMA bump the previous generation would otherwise live on disk forever.
+ */
+function sweepOldGenerations(root: string): void {
+  try {
+    for (const name of readdirSync(root)) {
+      if (name === SCHEMA) continue
+      try {
+        rmSync(join(root, name), { recursive: true, force: true })
+      } catch {
+        /* skip generations we can't remove */
       }
     }
   } catch {

--- a/src/shared/http/etag-store.ts
+++ b/src/shared/http/etag-store.ts
@@ -8,8 +8,9 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs'
-import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import envPaths from 'env-paths'
+import { PACKAGE_NAME } from '../config'
 import type { PackageVersionData } from '../registry/npm-registry'
 
 /**
@@ -51,9 +52,12 @@ export function setEtagCacheEnabled(value: boolean): void {
 
 /** Resolve (and lazily create) the cache directory, sweeping stale entries once. */
 function cacheDir(): string {
-  // Version data is not project-specific, so it lives in the OS temp area, shared
-  // across every project the user scans.
-  const dir = join(tmpdir(), 'inup', 'etag-cache', SCHEMA)
+  // Version data is not project-specific, so it lives in the per-user cache
+  // directory (env-paths, like the config dir), shared across every project the
+  // user scans. It used to live in the OS temp dir, but macOS clears that on
+  // reboot and Linux distros sweep it periodically — throwing the cache away
+  // exactly when it is most useful.
+  const dir = join(envPaths(PACKAGE_NAME).cache, 'etag-cache', SCHEMA)
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true })
   }

--- a/src/shared/registry/version-checker.ts
+++ b/src/shared/registry/version-checker.ts
@@ -1,6 +1,8 @@
-import { execSync } from 'child_process'
 import * as semver from 'semver'
-import { REQUEST_TIMEOUT } from '../config'
+import { NPM_REGISTRY_URL } from '../config'
+
+/** Cap for the self-update check; it must never hold up an interactive session. */
+const UPDATE_CHECK_TIMEOUT_MS = 5000
 
 export interface VersionCheckResult {
   currentVersion: string
@@ -10,21 +12,31 @@ export interface VersionCheckResult {
 }
 
 /**
- * Check if the current package version is outdated compared to npm registry
+ * Check if the current package version is outdated compared to npm registry.
+ *
+ * One small registry request (`{registry}/{name}/latest`) instead of spawning
+ * the npm CLI — `npm view` paid a few hundred ms of process startup for the
+ * same answer.
  */
 export async function checkForUpdate(
   packageName: string,
   currentVersion: string
 ): Promise<VersionCheckResult | null> {
   try {
-    // Use npm view to get the latest version from registry
-    const result = execSync(`npm view ${packageName} version`, {
-      encoding: 'utf-8',
-      timeout: REQUEST_TIMEOUT,
-      stdio: ['pipe', 'pipe', 'pipe'],
+    const response = await fetch(`${NPM_REGISTRY_URL}/${encodeURIComponent(packageName)}/latest`, {
+      method: 'GET',
+      headers: { accept: 'application/json' },
+      signal: AbortSignal.timeout(UPDATE_CHECK_TIMEOUT_MS),
     })
+    if (!response.ok) {
+      return null
+    }
 
-    const latestVersion = result.trim()
+    const manifest = (await response.json()) as { version?: string }
+    const latestVersion = typeof manifest.version === 'string' ? manifest.version.trim() : ''
+    if (!semver.valid(latestVersion)) {
+      return null
+    }
 
     // Compare versions
     const isOutdated = semver.lt(currentVersion, latestVersion)

--- a/src/shared/registry/version-checker.ts
+++ b/src/shared/registry/version-checker.ts
@@ -60,27 +60,14 @@ export async function checkForUpdate(
 }
 
 /**
- * Check for updates in the background without blocking
- * Resolves immediately, result available via promise
+ * Check for updates in the background without blocking.
+ *
+ * `checkForUpdate` self-caps at UPDATE_CHECK_TIMEOUT_MS and never rejects
+ * (every failure resolves to null), so no extra timeout race is needed here.
  */
 export function checkForUpdateAsync(
   packageName: string,
   currentVersion: string
 ): Promise<VersionCheckResult | null> {
-  return new Promise((resolve) => {
-    // Set a timeout to prevent hanging
-    const timeout = setTimeout(() => {
-      resolve(null)
-    }, 5000)
-
-    checkForUpdate(packageName, currentVersion)
-      .then((result) => {
-        clearTimeout(timeout)
-        resolve(result)
-      })
-      .catch(() => {
-        clearTimeout(timeout)
-        resolve(null)
-      })
-  })
+  return checkForUpdate(packageName, currentVersion)
 }

--- a/test/unit/features/changelog/github-client.test.ts
+++ b/test/unit/features/changelog/github-client.test.ts
@@ -85,6 +85,55 @@ describe('GitHubClient.fetchReleaseByTag', () => {
     expect(headers['authorization']).toBeUndefined()
   })
 
+  it('falls back to GH_TOKEN when GITHUB_TOKEN is unset', async () => {
+    vi.stubEnv('GITHUB_TOKEN', '')
+    vi.stubEnv('GH_TOKEN', 'gh-cli-token')
+    fetchMock.mockResolvedValue(jsonResponse({ body: 'notes' }))
+
+    await client.fetchReleaseByTag(REPO_URL, 'v1.0.0', signal)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('api.github.com'),
+      expect.objectContaining({
+        headers: expect.objectContaining({ authorization: 'Bearer gh-cli-token' }),
+      })
+    )
+  })
+
+  it('retries anonymously when the ambient token is rejected (401)', async () => {
+    // A stale/revoked token in the environment must never lose release notes
+    // that an anonymous request would have fetched.
+    vi.stubEnv('GITHUB_TOKEN', 'stale-token')
+    fetchMock
+      .mockResolvedValueOnce({ ok: false, status: 401, json: async () => ({}) })
+      .mockResolvedValueOnce(jsonResponse({ body: 'notes' }))
+
+    const body = await client.fetchReleaseByTag(REPO_URL, 'v1.0.0', signal)
+
+    expect(body).toBe('notes')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const retryHeaders = (fetchMock.mock.calls[1][1] as { headers: Record<string, string> }).headers
+    expect(retryHeaders['authorization']).toBeUndefined()
+    expect(retryHeaders['user-agent']).toBeDefined()
+  })
+
+  it('does not retry non-401 failures', async () => {
+    vi.stubEnv('GITHUB_TOKEN', 'valid-token')
+    fetchMock.mockResolvedValue({ ok: false, status: 404, json: async () => ({}) })
+
+    expect(await client.fetchReleaseByTag(REPO_URL, 'v1.0.0', signal)).toBeNull()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('never retries with credentials when the request was already anonymous', async () => {
+    vi.stubEnv('GITHUB_TOKEN', '')
+    vi.stubEnv('GH_TOKEN', '')
+    fetchMock.mockResolvedValue({ ok: false, status: 401, json: async () => ({}) })
+
+    expect(await client.fetchReleaseByTag(REPO_URL, 'v1.0.0', signal)).toBeNull()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('returns null for missing releases, empty bodies, and network errors', async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({}, false))
     expect(await client.fetchReleaseByTag(REPO_URL, 'v1.0.0', signal)).toBeNull()

--- a/test/unit/features/changelog/github-client.test.ts
+++ b/test/unit/features/changelog/github-client.test.ts
@@ -39,6 +39,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
 })
 
 describe('GitHubClient.fetchReleaseByTag', () => {
@@ -57,6 +58,31 @@ describe('GitHubClient.fetchReleaseByTag', () => {
       'https://api.github.com/repos/octo/demo/releases/tags/v1.0.0',
       expect.objectContaining({ method: 'GET' })
     )
+  })
+
+  it('authenticates api.github.com requests when GITHUB_TOKEN is set', async () => {
+    vi.stubEnv('GITHUB_TOKEN', 'gh-token-123')
+    fetchMock.mockResolvedValue(jsonResponse({ body: 'notes' }))
+
+    await client.fetchReleaseByTag(REPO_URL, 'v1.0.0', signal)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('api.github.com'),
+      expect.objectContaining({
+        headers: expect.objectContaining({ authorization: 'Bearer gh-token-123' }),
+      })
+    )
+  })
+
+  it('stays anonymous without an ambient token', async () => {
+    vi.stubEnv('GITHUB_TOKEN', '')
+    vi.stubEnv('GH_TOKEN', '')
+    fetchMock.mockResolvedValue(jsonResponse({ body: 'notes' }))
+
+    await client.fetchReleaseByTag(REPO_URL, 'v1.0.0', signal)
+
+    const headers = (fetchMock.mock.calls[0][1] as { headers: Record<string, string> }).headers
+    expect(headers['authorization']).toBeUndefined()
   })
 
   it('returns null for missing releases, empty bodies, and network errors', async () => {

--- a/test/unit/shared/http/etag-store.test.ts
+++ b/test/unit/shared/http/etag-store.test.ts
@@ -1,25 +1,35 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { rmSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import {
   readEtag,
   writeEtag,
   setEtagCacheEnabled,
+  setEtagCacheRoot,
   etagCacheDir,
 } from '../../../../src/shared/http/etag-store'
 
 const data = { latestVersion: '2.0.0', allVersions: ['2.0.0', '1.0.0'] }
 
+// Every test runs against an isolated throwaway root: the suite must never
+// touch (or race other parallel test files on) the user's real persistent
+// cache directory.
+let testRoot: string
+
+beforeEach(() => {
+  testRoot = mkdtempSync(join(tmpdir(), 'inup-etag-test-'))
+  setEtagCacheRoot(testRoot)
+  setEtagCacheEnabled(true)
+})
+
+afterEach(() => {
+  setEtagCacheRoot(null)
+  setEtagCacheEnabled(true)
+  rmSync(testRoot, { recursive: true, force: true })
+})
+
 describe('etag-store', () => {
-  beforeEach(() => {
-    setEtagCacheEnabled(true)
-    // Start from a clean cache dir each test.
-    rmSync(etagCacheDir(), { recursive: true, force: true })
-  })
-
-  afterEach(() => {
-    setEtagCacheEnabled(true)
-  })
-
   it('round-trips an etag + data entry', () => {
     expect(readEtag('/some-pkg')).toBeNull()
     writeEtag('/some-pkg', 'W/"abc123"', data)
@@ -53,31 +63,57 @@ describe('etag-store', () => {
     writeEtag('/pkg', 'etag2', data) // valid again
     expect(readEtag('/pkg')?.etag).toBe('etag2')
   })
+
+  it('resolves the cache dir under the configured root', () => {
+    expect(etagCacheDir().startsWith(testRoot)).toBe(true)
+  })
+
+  it('recreates the cache dir after it is deleted mid-process', () => {
+    writeEtag('/pkg', 'etag', data)
+    rmSync(etagCacheDir(), { recursive: true, force: true })
+
+    // The resolved path is memoized, but the mkdir guard must still run per
+    // write — otherwise a swept cache silently disables the store for the
+    // rest of the process.
+    writeEtag('/pkg', 'etag-after-wipe', data)
+    expect(readEtag('/pkg')?.etag).toBe('etag-after-wipe')
+  })
+
+  it('sweeps orphaned schema generations from the persistent root', () => {
+    // The cache root is persistent now (env-paths, not tmpdir), so old
+    // generations must be reclaimed by the store itself after a SCHEMA bump.
+    const oldGeneration = join(testRoot, 'v0')
+    mkdirSync(oldGeneration, { recursive: true })
+    writeFileSync(join(oldGeneration, 'stale.json'), '{}')
+
+    // First cache access triggers the one-time sweep.
+    readEtag('/anything')
+
+    expect(existsSync(oldGeneration)).toBe(false)
+    expect(existsSync(etagCacheDir())).toBe(true)
+  })
 })
 
 describe('etag-store corruption handling', () => {
   it('treats corrupt cache entries as a miss', async () => {
-    const { writeFileSync, readdirSync } = await import('node:fs')
-    const { join } = await import('node:path')
+    const { writeFileSync: write, readdirSync } = await import('node:fs')
 
-    setEtagCacheEnabled(true)
     writeEtag('/corrupt-pkg', 'W/"x"', data)
     const dir = etagCacheDir()
     for (const name of readdirSync(dir)) {
-      writeFileSync(join(dir, name), '{not json')
+      write(join(dir, name), '{not json')
     }
 
     expect(readEtag('/corrupt-pkg')).toBeNull()
   })
 
   it('rejects structurally invalid entries', async () => {
-    const { writeFileSync, readdirSync } = await import('node:fs')
-    const { join } = await import('node:path')
+    const { writeFileSync: write, readdirSync } = await import('node:fs')
 
     writeEtag('/invalid-pkg', 'W/"x"', data)
     const dir = etagCacheDir()
     for (const name of readdirSync(dir)) {
-      writeFileSync(join(dir, name), JSON.stringify({ etag: 42 }))
+      write(join(dir, name), JSON.stringify({ etag: 42 }))
     }
 
     expect(readEtag('/invalid-pkg')).toBeNull()

--- a/test/unit/shared/registry/npm-registry.test.ts
+++ b/test/unit/shared/registry/npm-registry.test.ts
@@ -13,8 +13,10 @@ import {
   fetchPackageVersions,
 } from '../../../../src/shared/registry/npm-registry'
 import type { ControlTick } from '../../../../src/shared/http/adaptive-controller'
-import { setEtagCacheEnabled, etagCacheDir } from '../../../../src/shared/http/etag-store'
-import { rmSync } from 'node:fs'
+import { setEtagCacheEnabled, setEtagCacheRoot } from '../../../../src/shared/http/etag-store'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 type MockResponse = {
   statusCode: number
@@ -330,11 +332,20 @@ describe('npm-registry', () => {
   })
 
   describe('ETag conditional caching', () => {
+    // Isolated root per test: never wipe (or race parallel test files on) the
+    // user's real persistent cache directory.
+    let etagTestRoot: string
+
     beforeEach(() => {
+      etagTestRoot = mkdtempSync(join(tmpdir(), 'inup-npm-registry-etag-'))
+      setEtagCacheRoot(etagTestRoot)
       setEtagCacheEnabled(true)
-      rmSync(etagCacheDir(), { recursive: true, force: true })
     })
-    afterEach(() => setEtagCacheEnabled(false))
+    afterEach(() => {
+      setEtagCacheRoot(null)
+      setEtagCacheEnabled(false)
+      rmSync(etagTestRoot, { recursive: true, force: true })
+    })
 
     it('stores the ETag on a 200 and reuses data on a subsequent 304', async () => {
       // First run: 200 with an ETag and a body → stores {etag, data}.

--- a/test/unit/shared/registry/version-checker.test.ts
+++ b/test/unit/shared/registry/version-checker.test.ts
@@ -92,6 +92,30 @@ describe('checkForUpdate', () => {
 
     expect(await checkForUpdate(PACKAGE_NAME, '1.0.0')).toBeNull()
   })
+
+  it('fails silently when the request times out', async () => {
+    // AbortSignal.timeout rejects the fetch with a TimeoutError DOMException.
+    fetchMock.mockRejectedValue(new DOMException('The operation timed out', 'TimeoutError'))
+
+    expect(await checkForUpdate(PACKAGE_NAME, '1.0.0')).toBeNull()
+  })
+
+  it('fails silently on malformed JSON bodies', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => {
+        throw new SyntaxError('Unexpected token < in JSON')
+      },
+    })
+
+    expect(await checkForUpdate(PACKAGE_NAME, '1.0.0')).toBeNull()
+  })
+
+  it('fails silently when the manifest version is not a string', async () => {
+    fetchMock.mockResolvedValue(versionResponse(42))
+
+    expect(await checkForUpdate(PACKAGE_NAME, '1.0.0')).toBeNull()
+  })
 })
 
 describe('checkForUpdateAsync', () => {

--- a/test/unit/shared/registry/version-checker.test.ts
+++ b/test/unit/shared/registry/version-checker.test.ts
@@ -1,36 +1,38 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { execSync } from 'child_process'
 import {
   checkForUpdate,
   checkForUpdateAsync,
 } from '../../../../src/shared/registry/version-checker'
-import { PACKAGE_NAME } from '../../../../src/shared/config/constants'
+import { NPM_REGISTRY_URL, PACKAGE_NAME } from '../../../../src/shared/config/constants'
 
-// `npm view` is mocked so this suite is deterministic and offline-safe.
-vi.mock('child_process', async (importOriginal) => {
-  const original = await importOriginal<typeof import('child_process')>()
-  return { ...original, execSync: vi.fn() }
+// The registry request is mocked so this suite is deterministic and offline-safe.
+const fetchMock = vi.fn()
+
+const versionResponse = (version: unknown, ok = true) => ({
+  ok,
+  json: async () => ({ version }),
 })
 
-const execMock = vi.mocked(execSync)
 const originalArgv1 = process.argv[1]
 
 beforeEach(() => {
-  execMock.mockReset()
-  execMock.mockReturnValue('2.0.0\n')
+  fetchMock.mockReset()
+  fetchMock.mockResolvedValue(versionResponse('2.0.0'))
+  vi.stubGlobal('fetch', fetchMock)
 })
 
 afterEach(() => {
   process.argv[1] = originalArgv1
+  vi.unstubAllGlobals()
 })
 
 describe('checkForUpdate', () => {
-  it('queries the registry via npm view', async () => {
+  it('queries the registry latest endpoint directly (no npm spawn)', async () => {
     await checkForUpdate(PACKAGE_NAME, '1.0.0')
 
-    expect(execMock).toHaveBeenCalledWith(
-      `npm view ${PACKAGE_NAME} version`,
-      expect.objectContaining({ encoding: 'utf-8' })
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${NPM_REGISTRY_URL}/${PACKAGE_NAME}/latest`,
+      expect.objectContaining({ method: 'GET' })
     )
   })
 
@@ -73,16 +75,20 @@ describe('checkForUpdate', () => {
     expect(result?.updateCommand).toBe(`npm install -g ${PACKAGE_NAME}@latest`)
   })
 
-  it('fails silently when npm is unavailable', async () => {
-    execMock.mockImplementation(() => {
-      throw new Error('npm not found')
-    })
+  it('fails silently when the registry is unreachable', async () => {
+    fetchMock.mockRejectedValue(new Error('offline'))
+
+    expect(await checkForUpdate(PACKAGE_NAME, '1.0.0')).toBeNull()
+  })
+
+  it('fails silently on non-2xx responses', async () => {
+    fetchMock.mockResolvedValue(versionResponse(undefined, false))
 
     expect(await checkForUpdate(PACKAGE_NAME, '1.0.0')).toBeNull()
   })
 
   it('fails silently on unparseable registry output', async () => {
-    execMock.mockReturnValue('not-a-version\n')
+    fetchMock.mockResolvedValue(versionResponse('not-a-version'))
 
     expect(await checkForUpdate(PACKAGE_NAME, '1.0.0')).toBeNull()
   })
@@ -97,9 +103,7 @@ describe('checkForUpdateAsync', () => {
   })
 
   it('resolves null instead of rejecting on failure', async () => {
-    execMock.mockImplementation(() => {
-      throw new Error('offline')
-    })
+    fetchMock.mockRejectedValue(new Error('offline'))
 
     await expect(checkForUpdateAsync(PACKAGE_NAME, '1.0.0')).resolves.toBeNull()
   })


### PR DESCRIPTION
## What

Three dependency-free improvements spotted during the dependency review:

1. **ETag cache survives reboots.** The on-disk ETag cache moved from `os.tmpdir()/inup/…` to the env-paths cache directory (`~/Library/Caches/inup-nodejs`, `~/.cache/inup-nodejs`, `%LOCALAPPDATA%`), matching how the config dir already works. macOS clears the temp dir on reboot and Linux distros sweep it periodically — throwing the cache away exactly when it's most useful. Old tmp entries are simply orphaned (the OS cleans them); the 14-day sweep and schema versioning are unchanged.
2. **GitHub API rate limits.** The changelog client sends `Authorization: Bearer <token>` to `api.github.com` when `GITHUB_TOKEN` or `GH_TOKEN` is present (GitHub Actions sets the former automatically): 5,000 req/hr instead of the anonymous 60 req/hr, which a long release-notes browsing session can exhaust. Only the two `api.github.com` call sites are authenticated — the token is never sent to `raw.githubusercontent.com` or the HTML fallback.
3. **Faster startup.** The self-update check now issues one small registry GET (`{registry}/inup/latest`) instead of spawning `npm view inup version` — spawning npm cost a few hundred ms of process startup on every launch for the same answer. Same silent-failure semantics, same 5s cap.

## Honest note on the fourth planned item

The assessment flagged `spawnSync(..., { shell: true })` in the upgrader as a potential command-injection surface. On inspection that was **wrong**: every shelled command in the codebase is a fixed, hardcoded string (`pnpm install --no-frozen-lockfile`, `npm view inup version`, `<pm> --version`, git probes) — package names are written to package.json via `JSON.stringify`, never interpolated into a shell. Converting to args arrays would gain no security and would *break Windows* (`.cmd` shims require a shell). No change made.

## Testing

- `version-checker` suite rewritten to mock `fetch` (still offline-safe), including non-2xx and unparseable-version fallbacks.
- New `github-client` tests for the authenticated and anonymous header paths (env stubbed both ways).
- `etag-store` tests were already location-agnostic via `etagCacheDir()` — unchanged and green.
- Full suite: 890 passed. Live run confirmed entries appear under `~/Library/Caches/inup-nodejs/etag-cache/v1/` and the CLI behaves identically.
