### PR TITLE
refactor/terminal-width-stack

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,11 +69,15 @@
   },
   "dependencies": {
     "chalk": "^5.6.2",
+    "cli-truncate": "^6.1.0",
     "commander": "^15.0.0",
     "env-paths": "^4.0.0",
     "nanospinner": "^1.2.2",
     "semver": "^7.8.5",
-    "undici": "^8.5.0"
+    "string-width": "^8.2.1",
+    "strip-ansi": "^7.2.0",
+    "undici": "^8.5.0",
+    "wrap-ansi": "^10.0.0"
   },
   "engines": {
     "node": ">=22.19.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
+      cli-truncate:
+        specifier: ^6.1.0
+        version: 6.1.0
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -23,9 +26,18 @@ importers:
       semver:
         specifier: ^7.8.5
         version: 7.8.5
+      string-width:
+        specifier: ^8.2.1
+        version: 8.2.1
+      strip-ansi:
+        specifier: ^7.2.0
+        version: 7.2.0
       undici:
         specifier: ^8.5.0
         version: 8.5.0
+      wrap-ansi:
+        specifier: ^10.0.0
+        version: 10.0.0
     devDependencies:
       '@types/node':
         specifier: ^25.9.4
@@ -453,9 +465,17 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -475,6 +495,10 @@ packages:
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  cli-truncate@6.1.0:
+    resolution: {integrity: sha512-ofWtXdvPO1WepoE9Gn4dPdZw+ADud1Yz9K+xm9FjK5vvrs/D60vrlKIQeSw1wJX4cphW2bnWi8GZSKvf9T6shw==}
+    engines: {node: '>=22'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -539,6 +563,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
     engines: {node: '>=18'}
@@ -572,6 +600,10 @@ packages:
   is-core-module@2.16.2:
     resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
     engines: {node: '>= 0.4'}
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
 
   is-installed-globally@1.0.0:
     resolution: {integrity: sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==}
@@ -691,6 +723,10 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  slice-ansi@9.0.0:
+    resolution: {integrity: sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==}
+    engines: {node: '>=22'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -700,6 +736,14 @@ packages:
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  string-width@8.2.1:
+    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
+    engines: {node: '>=20'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -842,6 +886,10 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wrap-ansi@10.0.0:
+    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
+    engines: {node: '>=20'}
 
 snapshots:
 
@@ -1110,9 +1158,13 @@ snapshots:
 
   acorn@8.17.0: {}
 
+  ansi-regex@6.2.2: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
 
   assertion-error@2.0.1: {}
 
@@ -1130,6 +1182,11 @@ snapshots:
       supports-color: 7.2.0
 
   chalk@5.6.2: {}
+
+  cli-truncate@6.1.0:
+    dependencies:
+      slice-ansi: 9.0.0
+      string-width: 8.2.1
 
   color-convert@2.0.1:
     dependencies:
@@ -1219,6 +1276,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  get-east-asian-width@1.6.0: {}
+
   global-directory@4.0.1:
     dependencies:
       ini: 4.1.1
@@ -1242,6 +1301,10 @@ snapshots:
   is-core-module@2.16.2:
     dependencies:
       hasown: 2.0.4
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
 
   is-installed-globally@1.0.0:
     dependencies:
@@ -1370,11 +1433,25 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  slice-ansi@9.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
 
   std-env@4.0.0: {}
+
+  string-width@8.2.1:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
 
@@ -1462,3 +1539,9 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrap-ansi@10.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 8.2.1
+      strip-ansi: 7.2.0

--- a/src/features/interactive/modal/package-info-sections/sections.ts
+++ b/src/features/interactive/modal/package-info-sections/sections.ts
@@ -115,8 +115,8 @@ export function buildPackageInfoSections(
     // Wrap (don't truncate) so a deprecation URL stays whole and clickable —
     // truncation with "..." produces a dead link. `wrapPlainText` breaks on
     // spaces only, so the URL keeps its own intact line. No emoji marker:
-    // `getVisualLength` scores glyphs like ⚠ as width 2 while many terminals
-    // render them as width 1, which throws off the modal's border alignment.
+    // terminal fonts disagree on whether such glyphs render one or two columns
+    // wide, which throws off the modal's border alignment.
     for (const line of wrapPlainText(`Deprecated: ${state.deprecated}`, warningContentWidth)) {
       warningRows.push(getThemeColor('warning')(line))
     }

--- a/src/shared/terminal/text.ts
+++ b/src/shared/terminal/text.ts
@@ -1,50 +1,20 @@
-const ANSI_PATTERN = /\[[0-9;?]*[ -/]*[@-~]/g
-const OSC8_PATTERN = /]8;;.*?(?:|\\)|]8;;(?:|\\)/g
+import stringWidth from 'string-width'
+import stripAnsiPackaged from 'strip-ansi'
+import wrapAnsi from 'wrap-ansi'
+import cliTruncate from 'cli-truncate'
+
+// Thin wrappers over the battle-tested terminal-string stack (string-width,
+// strip-ansi, wrap-ansi, cli-truncate). The previous hand-rolled versions
+// handled emoji but had no East Asian Width tables, so CJK text was counted at
+// width 1 and misaligned every column that contained it.
 
 export function stripAnsi(text: string): string {
-  return text.replace(OSC8_PATTERN, '').replace(ANSI_PATTERN, '')
+  return stripAnsiPackaged(text)
 }
 
+/** Terminal columns `text` occupies: ANSI-aware, emoji- and CJK-correct. */
 export function getVisualLength(text: string): number {
-  const cleaned = stripAnsi(text)
-  const SegmenterCtor = (
-    Intl as typeof Intl & {
-      Segmenter?: new (
-        locales?: string | string[],
-        options?: { granularity: 'grapheme' }
-      ) => {
-        segment(input: string): Iterable<{ segment: string }>
-      }
-    }
-  ).Segmenter
-  let length = 0
-
-  const segments = SegmenterCtor
-    ? SegmenterCtor.prototype.segment.call(
-        new SegmenterCtor(undefined, { granularity: 'grapheme' }),
-        cleaned
-      )
-    : cleaned
-
-  for (const item of segments) {
-    const segment = typeof item === 'string' ? item : item.segment
-    if (/\p{Extended_Pictographic}/u.test(segment) || segment.includes('\uFE0F')) {
-      length += 2
-    } else {
-      for (const char of segment) {
-        const codePoint = char.codePointAt(0) ?? 0
-        if (
-          (codePoint >= 0xfe00 && codePoint <= 0xfe0f) ||
-          (codePoint >= 0x0300 && codePoint <= 0x036f)
-        ) {
-          continue
-        }
-        length += 1
-      }
-    }
-  }
-
-  return length
+  return stringWidth(text)
 }
 
 export function truncatePlainText(text: string, maxWidth: number): string {
@@ -60,7 +30,7 @@ export function truncatePlainText(text: string, maxWidth: number): string {
     return '.'.repeat(maxWidth)
   }
 
-  return text.substring(0, maxWidth - 3) + '...'
+  return cliTruncate(text, maxWidth, { truncationCharacter: '...' })
 }
 
 export function wrapPlainText(text: string, maxWidth: number): string[] {
@@ -72,25 +42,7 @@ export function wrapPlainText(text: string, maxWidth: number): string[] {
     return [text]
   }
 
-  const lines: string[] = []
-  let current = ''
-  const words = text.split(' ')
-
-  for (const word of words) {
-    const candidate = (current + ' ' + word).trim()
-    if (getVisualLength(candidate) > maxWidth) {
-      if (current) {
-        lines.push(current)
-      }
-      current = word
-    } else {
-      current = current ? `${current} ${word}` : word
-    }
-  }
-
-  if (current) {
-    lines.push(current)
-  }
-
-  return lines
+  // Soft wrap: words longer than maxWidth get their own (overflowing) line,
+  // matching the previous behavior. ANSI codes are re-balanced per line.
+  return wrapAnsi(text, maxWidth).split('\n')
 }

--- a/test/unit/features/interactive/modal-layout.test.ts
+++ b/test/unit/features/interactive/modal-layout.test.ts
@@ -40,8 +40,11 @@ describe('modal layout primitives', () => {
     expect(getVisualLength(`${chalk.red('abc')}🙂`)).toBe(5)
   })
 
-  it('treats emoji variation selectors as zero-width', () => {
+  it('measures emoji presentation (VS16) as wide, text presentation as narrow', () => {
     expect(getVisualLength('ℹ️')).toBe(2)
-    expect(getVisualLength('⚠')).toBe(2)
+    // Bare U+26A0 has text presentation: terminals render it one column wide,
+    // and string-width agrees (the old heuristic mis-scored it as 2).
+    expect(getVisualLength('⚠')).toBe(1)
+    expect(getVisualLength('⚠️')).toBe(2)
   })
 })

--- a/test/unit/features/interactive/modal-layout.test.ts
+++ b/test/unit/features/interactive/modal-layout.test.ts
@@ -47,4 +47,35 @@ describe('modal layout primitives', () => {
     expect(getVisualLength('⚠')).toBe(1)
     expect(getVisualLength('⚠️')).toBe(2)
   })
+
+  it('keeps borders aligned across plain, CJK, emoji, colored, and hyperlink rows', () => {
+    const modalWidth = 40
+    const padding = 3
+    const rows = [
+      'plain text',
+      '你好世界パッケージ',
+      'emoji 🚀 and family 👨‍👩‍👧‍👦',
+      `${chalk.red('colored')} ${chalk.bold('bold')}`,
+      '\u001b]8;;https://example.com\u0007homepage\u001b]8;;\u0007',
+      '',
+    ]
+
+    // Every row must render at exactly padding + modalWidth columns, or the
+    // right border drifts. This is the invariant the width swap must uphold.
+    const widths = rows.map((row) => getVisualLength(renderModalRow(padding, modalWidth, row)))
+    expect(widths).toEqual(rows.map(() => padding + modalWidth))
+  })
+
+  it('renders every frame line at the same visual width with mixed content', () => {
+    const lines = renderModalFrame(
+      [
+        { key: 'header', rows: ['📦 test-pkg'], required: true },
+        { key: 'description', rows: ['一个用于升级依赖的交互式命令行工具'] },
+      ],
+      { terminalWidth: 80, terminalHeight: 20, minWidth: 60, maxWidth: 60 }
+    )
+
+    const widths = lines.filter((line) => line !== '').map((line) => getVisualLength(line))
+    expect(new Set(widths).size).toBe(1)
+  })
 })

--- a/test/unit/features/interactive/package-info-sections.test.ts
+++ b/test/unit/features/interactive/package-info-sections.test.ts
@@ -12,7 +12,7 @@ import {
   pushWrappedLines,
   sanitizeMarkdownText,
 } from '../../../../src/features/interactive/modal/package-info-sections/text'
-import { stripAnsi } from '../../../../src/shared/terminal/text'
+import { getVisualLength, stripAnsi } from '../../../../src/shared/terminal/text'
 import { makeSelectionState } from '../../../fixtures/selection-state-factory'
 
 const MODAL_WIDTH = 70
@@ -179,6 +179,40 @@ describe('buildPackageInfoSections (info tab)', () => {
 
     expect(text).toContain('depend on test-pkg')
     expect(text).not.toContain('Current: ^1.0.0')
+  })
+
+  it('keeps every row within the content width for CJK/emoji registry text', () => {
+    // Registry metadata is arbitrary text: CJK descriptions, deprecation
+    // notices, and advisory titles all flow into modal rows. Any row wider
+    // than the content area pushes the right border out of alignment.
+    const state = makeSelectionState({
+      description:
+        '一个交互式命令行工具，用于升级过时的依赖项 🚀 パッケージ管理を簡単にするツールです、モノレポ対応',
+      deprecated:
+        'このパッケージは非推奨です。代わりに 别的包 を使ってください。移行ガイド: https://example.com/migrate',
+      homepage: 'https://example.com/你好/文档/getting-started',
+      vulnerability: {
+        count: 1,
+        highestSeverity: 'high',
+        detailsUrl: 'https://github.com/advisories/GHSA-demo',
+        advisories: [
+          {
+            id: 'GHSA-demo',
+            title: '原型污染の脆弱性が発見されました、直ちにアップグレードしてください',
+            severity: 'high',
+            url: 'https://github.com/advisories/GHSA-demo',
+          },
+        ],
+      },
+    })
+
+    const sections = buildPackageInfoSections(state, MODAL_WIDTH, 'info')
+
+    for (const section of sections) {
+      for (const row of section.rows) {
+        expect(getVisualLength(row)).toBeLessThanOrEqual(MODAL_WIDTH - 4)
+      }
+    }
   })
 })
 

--- a/test/unit/features/interactive/package-list.test.ts
+++ b/test/unit/features/interactive/package-list.test.ts
@@ -96,6 +96,44 @@ describe('package-list renderer', () => {
     expect(line).toContain('unavailable')
   })
 
+  it('renders every state variant at the same visual width so columns align', () => {
+    const variants = [
+      baseState,
+      makeSelectionState({
+        name: 'demo-pkg',
+        vulnerability: {
+          count: 2,
+          highestSeverity: 'high',
+          detailsUrl: 'https://github.com/advisories/GHSA-high',
+          advisories: [],
+        },
+      }),
+      makeSelectionState({ name: 'demo-pkg', deprecated: 'use something else instead' }),
+      makeSelectionState({
+        name: 'demo-pkg',
+        loadState: 'failed',
+        rangeVersion: 'unknown',
+        latestVersion: 'unknown',
+        hasRangeUpdate: false,
+        hasMajorUpdate: false,
+      }),
+      makeSelectionState({ name: '@scope/a-rather-long-package-name-for-testing' }),
+      makeSelectionState({ name: 'demo-pkg', type: 'devDependencies' }),
+    ]
+
+    // Rows use emoji badges and dot glyphs whose measured width feeds the
+    // column math. Whatever the state (badges, selection, failures, long
+    // names), every row must come out at the same visual width — one glyph
+    // measured differently from how it renders would shift the whole column.
+    for (const terminalWidth of [90, 120]) {
+      const widths = variants.flatMap((state) => [
+        VersionUtils.getVisualLength(renderPackageLine(state, 0, false, terminalWidth)),
+        VersionUtils.getVisualLength(renderPackageLine(state, 0, true, terminalWidth)),
+      ])
+      expect(new Set(widths).size).toBe(1)
+    }
+  })
+
   it('uses fixed-width vulnerability badges so rows stay aligned', () => {
     const highLine = renderPackageLine(
       {

--- a/test/unit/shared/terminal/text.test.ts
+++ b/test/unit/shared/terminal/text.test.ts
@@ -40,6 +40,13 @@ describe('getVisualLength', () => {
     // is inside the skipped combining range.
     expect(getVisualLength('è')).toBe(1)
   })
+  it('counts CJK characters as two terminal columns', () => {
+    // The old hand-rolled version had no East Asian Width tables and scored
+    // these as width 1, misaligning every column containing CJK text.
+    expect(getVisualLength('你好')).toBe(4)
+    expect(getVisualLength('パッケージ')).toBe(10)
+    expect(getVisualLength('한국어')).toBe(6)
+  })
 })
 
 describe('truncatePlainText', () => {
@@ -59,6 +66,13 @@ describe('truncatePlainText', () => {
 
   it('truncates with a three-dot ellipsis', () => {
     expect(truncatePlainText('hello world', 8)).toBe('hello...')
+  })
+
+  it('truncates by visual width, not code units', () => {
+    // Four CJK chars are 8 columns; a 7-column budget keeps two of them
+    // (4 columns) plus the 3-column ellipsis. The old version sliced by code
+    // units and could overflow the column.
+    expect(truncatePlainText('你好世界', 7)).toBe('你好...')
   })
 })
 

--- a/test/unit/shared/terminal/text.test.ts
+++ b/test/unit/shared/terminal/text.test.ts
@@ -12,7 +12,7 @@ describe('stripAnsi', () => {
   })
 
   it('removes OSC-8 hyperlink wrappers', () => {
-    expect(stripAnsi('\u001b]8;;https://example.comlink\u001b]8;;')).toBe('link')
+    expect(stripAnsi('\u001b]8;;https://example.com\u0007link\u001b]8;;\u0007')).toBe('link')
   })
 
   it('leaves plain text untouched', () => {
@@ -47,6 +47,29 @@ describe('getVisualLength', () => {
     expect(getVisualLength('パッケージ')).toBe(10)
     expect(getVisualLength('한국어')).toBe(6)
   })
+
+  it('measures complex grapheme clusters as single wide glyphs', () => {
+    expect(getVisualLength('👨‍👩‍👧‍👦')).toBe(2) // ZWJ family sequence
+    expect(getVisualLength('👍🏽')).toBe(2) // skin-tone modifier
+    expect(getVisualLength('🇺🇸')).toBe(2) // regional-indicator flag
+  })
+
+  it('measures OSC-8 hyperlinks by their visible label only', () => {
+    // The modal linkifies mentions/PRs/commits into OSC-8 hyperlinks; layout
+    // math must see only the label, or every linked row would be misaligned.
+    const hyperlink = '\u001b]8;;https://example.com\u0007docs\u001b]8;;\u0007'
+    expect(getVisualLength(hyperlink)).toBe(4)
+    expect(stripAnsi(hyperlink)).toBe('docs')
+  })
+
+  it('returns zero for empty and ANSI-only strings', () => {
+    expect(getVisualLength('')).toBe(0)
+    expect(getVisualLength('\u001b[31m\u001b[39m')).toBe(0)
+  })
+
+  it('measures colored CJK/emoji mixes by visible content', () => {
+    expect(getVisualLength('\u001b[31m你好\u001b[39m 🚀 ok')).toBe(10)
+  })
 })
 
 describe('truncatePlainText', () => {
@@ -74,6 +97,29 @@ describe('truncatePlainText', () => {
     // units and could overflow the column.
     expect(truncatePlainText('你好世界', 7)).toBe('你好...')
   })
+
+  it('drops a wide char that cannot fit rather than overflow an odd budget', () => {
+    // At width 6 a second wide char plus the ellipsis would need 7 columns,
+    // so only one CJK char survives (total width 5 ≤ 6).
+    expect(truncatePlainText('你好世界', 6)).toBe('你...')
+  })
+
+  it('never exceeds the width budget for any input', () => {
+    const inputs = [
+      'hello world',
+      '你好世界啊',
+      'パッケージ管理ツール',
+      'emoji 🚀🚀🚀 tail',
+      'ab 👨‍👩‍👧‍👦 cd',
+      'mixed 你好 text 🚀',
+    ]
+    for (const input of inputs) {
+      for (let width = 1; width <= 12; width++) {
+        const result = truncatePlainText(input, width)
+        expect(getVisualLength(result)).toBeLessThanOrEqual(width)
+      }
+    }
+  })
 })
 
 describe('wrapPlainText', () => {
@@ -92,5 +138,44 @@ describe('wrapPlainText', () => {
 
   it('puts an overlong word on its own line', () => {
     expect(wrapPlainText('a extraordinarily b', 6)).toEqual(['a', 'extraordinarily', 'b'])
+  })
+
+  it('wraps CJK text by visual width', () => {
+    // Each pair is 4 columns wide, so a 4-column budget fits exactly one pair
+    // per line. The old width-1-per-char math would have packed two.
+    expect(wrapPlainText('你好 世界 你好', 4)).toEqual(['你好', '世界', '你好'])
+  })
+
+  it('re-balances ANSI color codes across wrapped lines', () => {
+    // The old implementation wrapped ANSI-blind: an opened color bled across
+    // the line break and the padding after it.
+    const lines = wrapPlainText('\u001b[31mone two three four\u001b[39m', 8)
+
+    expect(lines.map(stripAnsi)).toEqual(['one two', 'three', 'four'])
+    for (const line of lines) {
+      expect(line).toContain('\u001b[31m') // color re-opened on every line
+      expect(line).toContain('\u001b[39m') // and closed before the break
+      expect(getVisualLength(line)).toBeLessThanOrEqual(8)
+    }
+  })
+
+  it('keeps every wrapped line within the width budget for any input', () => {
+    const inputs = [
+      'plain words to wrap around',
+      '你好 世界 你好 世界',
+      'emoji 🚀 rocket 🚀 tail',
+      'a 👨‍👩‍👧‍👦 b 👨‍👩‍👧‍👦 c',
+      'パッケージ 管理 ツール',
+    ]
+    for (const input of inputs) {
+      for (let width = 4; width <= 12; width++) {
+        for (const line of wrapPlainText(input, width)) {
+          // Overflow is only permitted for a single unbreakable word.
+          if (getVisualLength(line) > width) {
+            expect(line).not.toContain(' ')
+          }
+        }
+      }
+    }
   })
 })


### PR DESCRIPTION
## What

The shared terminal text utilities (`src/shared/terminal/text.ts`) are now thin wrappers over the standard terminal-string stack — [`string-width`](https://github.com/sindresorhus/string-width), [`strip-ansi`](https://github.com/chalk/strip-ansi), [`wrap-ansi`](https://github.com/chalk/wrap-ansi), [`cli-truncate`](https://github.com/sindresorhus/cli-truncate) — with the **exported API unchanged** (`getVisualLength`, `stripAnsi`, `wrapPlainText`, `truncatePlainText`), so no consumer changed.

The whole TUI depends on exact width math; the hand-rolled versions had real correctness gaps:

- **CJK misalignment**: `getVisualLength` had an emoji heuristic but no East Asian Width tables — 你好 / パッケージ / 한국어 counted 1 column per char, skewing every row/modal border containing CJK text (package descriptions commonly do). Now width 2, correctly.
- **Truncation by code units**: `truncatePlainText` sliced with `substring`, so a CJK string could overflow its column even after "truncation". Now cuts by visual width (`你好世界` @ 7 columns → `你好...`).
- **ANSI-unaware wrapping**: `wrapPlainText` now re-balances color codes across wrapped lines (wrap-ansi) instead of letting an unclosed escape bleed into the next line.
- **Text-presentation glyphs**: bare `⚠` (U+26A0, no VS16) measured 2 in the old heuristic while terminals render it at width 1 — the modal code even carried a workaround comment for exactly this. string-width measures 1; the stale comment and the test asserting the old quirk were updated.

Edge-case behavior is preserved verbatim: `'...'` ellipsis (not `…`), `maxWidth <= 3` dot-degradation, `''`/non-positive-width contracts, soft wrap that leaves overlong words unbroken on their own line.

## ESM note

All four packages are ESM-only and this is a CJS build — the same situation as the existing `chalk@5`/`env-paths@4` deps: Node's `require(esm)` handles it, guaranteed by the `engines.node >= 22.19` floor. Verified through the compiled `dist/` output, not just ts-node/vitest.

## Testing

- New unit tests: CJK widths (zh/ja/ko), visual-width truncation, VS16-vs-text-presentation measurement.
- Full suite (73 files / 889 tests) green — including the interactive renderer, package-list layout, and perf-modal suites that exercise the width math heavily.
- Smoke: compiled CLI runs end-to-end; `getVisualLength('你好世界') === 8` and `truncatePlainText('你好世界', 7) === '你好...'` confirmed through `dist/`.
