### PR TITLE
chore(deps): dependency upgrades

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "semver": "^7.8.5",
     "string-width": "^8.2.1",
     "strip-ansi": "^7.2.0",
-    "undici": "^8.5.0",
+    "undici": "^8.6.0",
     "wrap-ansi": "^10.0.0",
     "yaml": "^2.9.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^7.2.0
         version: 7.2.0
       undici:
-        specifier: ^8.5.0
-        version: 8.5.0
+        specifier: ^8.6.0
+        version: 8.6.0
       wrap-ansi:
         specifier: ^10.0.0
         version: 10.0.0
@@ -826,8 +826,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@8.5.0:
-    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
+  undici@8.6.0:
+    resolution: {integrity: sha512-l2FlC6I510GawyEd1qgcE/okihKrzy+BRTEBlu6T0fdbM9m5yxtIH5Oa3ysRsH0zC4EhmWUEaSDsy2QngBeRlw==}
     engines: {node: '>=22.19.0'}
 
   vite@7.3.1:
@@ -1557,7 +1557,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@8.5.0: {}
+  undici@8.6.0: {}
 
   vite@7.3.1(@types/node@25.9.4)(yaml@2.9.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ allowBuilds:
   esbuild: true
 minimumReleaseAgeExclude:
   - prettier@3.9.4
+  - undici@8.6.0


### PR DESCRIPTION
## 📦 Dependency upgrades

Scanned **19** packages — **2** unique upgrade(s) (1 with a major available, 0 with known vulnerabilities).

### ✅ Applied in this PR

- `undici` `^8.5.0` → `^8.6.0` (dependencies)

### Updates

| Package | Current | → In-range | Latest | Type | Applied | Major? | Security |
|---|---|---|---|---|---|---|---|
| `@types/node` | ^25.9.4 | ^^25.9.4 | 26.1.0 | devDependencies | — | ⚠️ yes | — |
| `undici` | ^8.5.0 | ^8.6.0 | 8.6.0 | dependencies | ✅ | — | — |

### ⏭️ Major updates available (not applied)

A new **major** version exists beyond the in-range bump above. Under the default `minor` policy the major jump is **not applied** — review and bump deliberately:

- `@types/node` (current `^25.9.4`) → **26.1.0** (devDependencies)

---

🤖 Opened by [inup](https://github.com/donfear/inup). Re-runs update this same PR.
