### PR TITLE
fix/marketplace-release-target-500

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,12 +78,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           # The Marketplace listing is bound to whichever release published it — one-time manual
-          # setup via the UI (Marketplace publishing can't be toggled through the API). Once that
-          # release exists for the floating tag, we just repoint it at each new commit so
-          # `donfear/inup@v1` in Marketplace always resolves to the latest v1.x.y.
+          # setup via the UI (Marketplace publishing can't be toggled through the API). Actions/
+          # Marketplace resolve `donfear/inup@v1` via the *git tag* (already force-moved above),
+          # not this release's target_commitish, so we only need to keep the notes current here.
+          #
+          # NB: `gh release edit --target` on this release reliably 500s (GitHub rejects
+          # target_commitish changes on a Marketplace-bound release) — don't pass --target.
           if gh release view "$MAJOR" >/dev/null 2>&1; then
             gh release edit "$MAJOR" \
-              --target "$(git rev-parse "$NEW_VERSION")" \
               --notes "Tracks the latest \`$MAJOR.x.y\` release for Marketplace users pinned to \`@$MAJOR\`. See [$NEW_VERSION]($(gh release view "$NEW_VERSION" --json url --jq .url)) for what's new."
           else
             echo "No existing '$MAJOR' release found — publish one manually once via the GitHub UI with 'Publish to Marketplace' checked, then this step will keep it in sync on future releases."


### PR DESCRIPTION
## Summary
- The release workflow's "Update floating major release for Marketplace" step calls `gh release edit v1 --target ... --notes ...` on every release.
- The `--target` flag reliably returns HTTP 500 for this release, because GitHub rejects `target_commitish` changes on a release that's bound to a Marketplace listing. Reproduced manually against the live API (raw `gh api ... -X PATCH -f target_commitish=...` also 500s; `-f body=...` alone succeeds).
- This isn't needed anyway: `donfear/inup@v1` is resolved by Actions/Marketplace via the **git tag** `v1`, which is already force-moved to the new release commit earlier in the same job (`git tag -f "$MAJOR" "$NEW_VERSION"` / `git push -f origin "$MAJOR"`). The release object's `target_commitish` is just display metadata on the releases page.
- Fix: drop `--target` from the `gh release edit` call, keep only `--notes`, and document why in a comment so it isn't re-added later.

## Test plan
- [x] Manually reproduced the 500 via `gh release edit v1 --target ...` and via raw `gh api -X PATCH -f target_commitish=...`
- [x] Confirmed `gh release edit v1 --notes ...` (no `--target`) succeeds
- [x] Confirmed tag `v1` already points at the latest release commit independent of the release object
- [x] Next real release run should complete the "Update floating major release for Marketplace" step without error