### PR TITLE
fix: make --apply --target patch bump patch versions only

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ inup [options]
 --json                        Print a machine-readable JSON report and exit (read-only)
 -c, --check                   Exit non-zero if updates exist, without writing (for CI)
 --apply                       Non-interactively write upgrades + install (for CI/automation)
---target <level>              With --apply: how far to bump — minor (default) | patch | latest
+--target <level>              With --apply: minor (default, in-range) | patch (same major.minor) | latest
 --debug                       Write verbose debug logs
 ```
 
@@ -94,7 +94,8 @@ inup --apply --target latest # include major bumps; --json to also emit the repo
 
 Unlike `--json` and `--check`, **`--apply` writes**: it bumps `package.json` and runs your package
 manager's install to update the lockfile. By default (`--target minor`) it only applies **in-range**
-updates and leaves majors for you to review; `--target latest` includes majors. It honors `.inuprc`
+updates and leaves majors for you to review; `--target patch` stays within the current
+`major.minor` line (patch bumps only); `--target latest` includes majors. It honors `.inuprc`
 (`ignore`, `exclude`, `scanDirs`) exactly as the report does — a package the config excludes is
 never written. With `--apply --json`, the install output goes to stderr so stdout stays pure JSON.
 

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ branding:
 
 inputs:
   target:
-    description: 'How far to bump: minor (in-range only, default), patch, or latest (includes majors).'
+    description: 'How far to bump: minor (in-range only, default), patch (same major.minor only), or latest (includes majors).'
     required: false
     default: 'minor'
   directory:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -203,7 +203,7 @@ program
   )
   .option(
     '--target <level>',
-    'with --apply: how far to bump — minor | patch | latest (default: minor, in-range only)',
+    'with --apply: how far to bump — minor (in-range) | patch (same major.minor only) | latest (default: minor)',
     'minor'
   )
   .action(runCli)

--- a/src/features/headless/headless-runner.ts
+++ b/src/features/headless/headless-runner.ts
@@ -7,7 +7,7 @@ import {
 } from '../../features/debug'
 import { PackageManagerDetector } from '../../shared/package-manager'
 import type { PackageInfo, PackageUpgradeChoice, UpgradeOptions } from '../../shared/types'
-import { applyVersionPrefix } from '../../shared/versions'
+import { applyVersionPrefix, findHighestPatchVersion } from '../../shared/versions'
 import { auditVulnerabilities } from '../audit'
 import { PackageDetector, PackageUpgrader } from '../upgrade'
 import { buildHeadlessReport, renderPlainReport } from './report'
@@ -113,8 +113,10 @@ export class HeadlessRunner {
    * Build `PackageUpgradeChoice[]` from the outdated set per the version policy. Mirrors
    * `createUpgradeChoices` in the TUI: preserves the original range prefix (^/~) unless --save-exact.
    *
-   * - minor/patch: take the in-range target (`rangeVersion`); skip packages whose only update is a
+   * - minor: take the in-range target (`rangeVersion`); skip packages whose only update is a
    *   major (no in-range bump). Uses upgradeType 'range'.
+   * - patch: take the highest patch in the current major.minor line; skip packages whose only
+   *   update crosses a minor (or major) boundary. Uses upgradeType 'range'.
    * - latest: take `latestVersion`; uses upgradeType 'latest' (majors included).
    */
   private buildChoices(outdated: PackageInfo[], target: ApplyTarget): PackageUpgradeChoice[] {
@@ -122,12 +124,7 @@ export class HeadlessRunner {
     const choices: PackageUpgradeChoice[] = []
 
     for (const pkg of outdated) {
-      const useLatest = target === 'latest'
-
-      // minor/patch only act on packages with an in-range bump; major-only updates are skipped.
-      if (!useLatest && !pkg.hasRangeUpdate) continue
-
-      const targetVersion = useLatest ? pkg.latestVersion : pkg.rangeVersion
+      const targetVersion = this.resolveTargetVersion(pkg, target)
       if (!targetVersion) continue
 
       const targetVersionWithPrefix = saveExact
@@ -138,7 +135,7 @@ export class HeadlessRunner {
         name: pkg.name,
         packageJsonPath: pkg.packageJsonPath,
         dependencyType: pkg.type,
-        upgradeType: useLatest ? 'latest' : 'range',
+        upgradeType: target === 'latest' ? 'latest' : 'range',
         targetVersion: targetVersionWithPrefix,
         currentVersionSpecifier: pkg.currentVersion,
         catalog: pkg.catalog,
@@ -146,6 +143,21 @@ export class HeadlessRunner {
     }
 
     return choices
+  }
+
+  /** Resolve the version a package should be bumped to under the given policy, or null to skip. */
+  private resolveTargetVersion(pkg: PackageInfo, target: ApplyTarget): string | null {
+    if (target === 'latest') {
+      return pkg.latestVersion || null
+    }
+    if (target === 'patch') {
+      // Strictly patch-level: computed from the full version list, not `rangeVersion` (which may
+      // be a minor bump). Null when the only updates cross a minor boundary.
+      return findHighestPatchVersion(pkg.currentVersion, pkg.allVersions ?? [])
+    }
+    // minor: in-range bump only; major-only updates are skipped.
+    if (!pkg.hasRangeUpdate) return null
+    return pkg.rangeVersion || null
   }
 
   /** Resolve the package manager the same way the interactive runner does. */

--- a/src/shared/versions.ts
+++ b/src/shared/versions.ts
@@ -104,7 +104,6 @@ export function findClosestMinorVersion(
 
     const installedMajor = semver.major(coercedInstalled)
     const installedMinor = semver.minor(coercedInstalled)
-    const installedPatch = semver.patch(coercedInstalled)
 
     let bestMinorVersion: string | null = null
     let bestMinorValue = -1
@@ -127,28 +126,48 @@ export function findClosestMinorVersion(
       return bestMinorVersion
     }
 
-    // Fallback: find highest patch version in same major.minor that's higher than installed
-    let bestPatchVersion: string | null = null
-    for (const version of allVersions) {
-      try {
-        const major = semver.major(version)
-        const minor = semver.minor(version)
-        const patch = semver.patch(version)
-        // Same major and minor, but higher patch
-        if (major === installedMajor && minor === installedMinor && patch > installedPatch) {
-          if (!bestPatchVersion || semver.gt(version, bestPatchVersion)) {
-            bestPatchVersion = version
-          }
-        }
-      } catch {
-        // Skip invalid versions
-      }
-    }
-
-    return bestPatchVersion
+    // Fallback: highest patch version in the same major.minor that's higher than installed
+    return findHighestPatchVersion(installedVersion, allVersions)
   } catch {
     return null
   }
+}
+
+/**
+ * Find the highest patch version in the installed version's own major.minor line.
+ * This is the `--target patch` policy: never crosses a minor (or major) boundary.
+ */
+export function findHighestPatchVersion(
+  installedVersion: string,
+  allVersions: string[]
+): string | null {
+  const coercedInstalled = semver.coerce(installedVersion)
+  if (!coercedInstalled) {
+    return null
+  }
+
+  const installedMajor = semver.major(coercedInstalled)
+  const installedMinor = semver.minor(coercedInstalled)
+  const installedPatch = semver.patch(coercedInstalled)
+
+  let bestPatchVersion: string | null = null
+  for (const version of allVersions) {
+    try {
+      const major = semver.major(version)
+      const minor = semver.minor(version)
+      const patch = semver.patch(version)
+      // Same major and minor, but higher patch
+      if (major === installedMajor && minor === installedMinor && patch > installedPatch) {
+        if (!bestPatchVersion || semver.gt(version, bestPatchVersion)) {
+          bestPatchVersion = version
+        }
+      }
+    } catch {
+      // Skip invalid versions
+    }
+  }
+
+  return bestPatchVersion
 }
 
 /** Re-apply the original specifier's range prefix (^, ~, >=, …) to a new version. */

--- a/test/unit/features/headless/headless-runner.test.ts
+++ b/test/unit/features/headless/headless-runner.test.ts
@@ -51,11 +51,27 @@ const OUTDATED = {
   currentVersion: '^0.27.0',
   rangeVersion: '0.27.2',
   latestVersion: '1.16.1',
+  allVersions: ['0.27.0', '0.27.1', '0.27.2', '1.0.0', '1.16.1'],
   type: 'dependencies',
   packageJsonPath: '/repo/package.json',
   isOutdated: true,
   hasRangeUpdate: true,
   hasMajorUpdate: true,
+}
+
+// The in-range bump crosses a minor boundary (no newer patch in 2.0.x). `--target patch` must
+// skip this package; `--target minor` takes it.
+const MINOR_ONLY = {
+  name: 'lodash-ish',
+  currentVersion: '~2.0.0',
+  rangeVersion: '2.3.0',
+  latestVersion: '2.3.0',
+  allVersions: ['2.0.0', '2.1.0', '2.3.0'],
+  type: 'dependencies',
+  packageJsonPath: '/repo/package.json',
+  isOutdated: true,
+  hasRangeUpdate: true,
+  hasMajorUpdate: false,
 }
 
 const UP_TO_DATE = {
@@ -219,6 +235,45 @@ describe('HeadlessRunner.run', () => {
         dependencyType: 'dependencies',
         packageJsonPath: '/repo/package.json',
       })
+      logSpy.mockRestore()
+    })
+
+    it('target=patch bumps only within the current major.minor line', async () => {
+      mocks.getOutdatedPackages.mockResolvedValue([OUTDATED, MINOR_ONLY, MAJOR_ONLY, UP_TO_DATE])
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      await new HeadlessRunner({ cwd: '/repo' }).run({ apply: true, target: 'patch' })
+
+      const choices = mocks.upgradePackages.mock.calls[0][0]
+      // axios has newer 0.27.x patches; lodash-ish only has minor bumps and chalk only a major —
+      // both must be skipped even though they have in-range updates.
+      expect(choices).toHaveLength(1)
+      expect(choices[0]).toMatchObject({
+        name: 'axios',
+        upgradeType: 'range',
+        targetVersion: '^0.27.2',
+      })
+      logSpy.mockRestore()
+    })
+
+    it('target=patch skips packages without version-list data', async () => {
+      const { allVersions: _omitted, ...withoutVersions } = OUTDATED
+      mocks.getOutdatedPackages.mockResolvedValue([withoutVersions])
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      await new HeadlessRunner({ cwd: '/repo' }).run({ apply: true, target: 'patch' })
+
+      expect(mocks.upgradePackages).not.toHaveBeenCalled()
+      logSpy.mockRestore()
+    })
+
+    it('target=latest skips packages whose latest version is empty', async () => {
+      mocks.getOutdatedPackages.mockResolvedValue([{ ...OUTDATED, latestVersion: '' }])
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      await new HeadlessRunner({ cwd: '/repo' }).run({ apply: true, target: 'latest' })
+
+      expect(mocks.upgradePackages).not.toHaveBeenCalled()
       logSpy.mockRestore()
     })
 

--- a/test/unit/shared/versions.test.ts
+++ b/test/unit/shared/versions.test.ts
@@ -3,6 +3,7 @@ import {
   applyVersionPrefix,
   extractMajorVersion,
   findClosestMinorVersion,
+  findHighestPatchVersion,
   getOptimizedRangeVersion,
   isVersionOutdated,
   parseVersions,
@@ -183,6 +184,37 @@ describe('version utils', () => {
 
     it('should not return a lower version when already on latest within major', () => {
       expect(findClosestMinorVersion('1.2.5', ['1.0.0', '1.2.3', '2.0.0'])).toBeNull()
+    })
+  })
+
+  describe('findHighestPatchVersion()', () => {
+    it('returns the highest patch in the same major.minor line', () => {
+      expect(findHighestPatchVersion('1.0.0', ['1.0.1', '1.0.2', '1.0.3', '2.0.0'])).toBe('1.0.3')
+    })
+
+    it('is order-independent when versions arrive descending', () => {
+      expect(findHighestPatchVersion('1.0.0', ['1.0.3', '1.0.1', '1.0.2'])).toBe('1.0.3')
+    })
+
+    it('never crosses a minor or major boundary', () => {
+      // Only minor/major updates exist — a patch policy must not take them.
+      expect(findHighestPatchVersion('1.0.2', ['1.0.0', '1.1.0', '1.2.5', '2.0.0'])).toBeNull()
+    })
+
+    it('handles range prefixes on the installed version', () => {
+      expect(findHighestPatchVersion('^1.0.0', ['1.0.1', '1.1.0'])).toBe('1.0.1')
+    })
+
+    it('returns null for an uncoercible installed version', () => {
+      expect(findHighestPatchVersion('invalid', ['1.0.1'])).toBeNull()
+    })
+
+    it('skips invalid versions in the array', () => {
+      expect(findHighestPatchVersion('1.0.0', ['not-a-version', '1.0.2'])).toBe('1.0.2')
+    })
+
+    it('returns null for an empty array', () => {
+      expect(findHighestPatchVersion('1.0.0', [])).toBeNull()
     })
   })
 })


### PR DESCRIPTION
## Problem

`--target patch` behaved exactly like `minor`: `buildChoices` in the headless runner only distinguished `latest`, so both `minor` and `patch` applied `rangeVersion` — the closest-*minor* target. A user (or the GitHub Action with `target: patch`) asking for patch-only bumps could silently get minor upgrades.

## Fix

- New `findHighestPatchVersion(installed, allVersions)` in `src/shared/versions.ts` — highest patch within the current `major.minor` line, extracted verbatim from the existing `findClosestMinorVersion` fallback (which now reuses it, behavior unchanged).
- `HeadlessRunner.buildChoices` resolves the target per policy: `patch` uses the new helper and skips packages whose only updates cross a minor boundary; `minor`/`latest` are unchanged.
- Documented the `patch` semantics in the CLI `--target` help, `action.yml` input description, and README.

## Verification

- New unit tests for the helper and for `target=patch` in the headless runner; full suite passes with the 100% coverage gate (1107 tests).
- E2E on a scratch project with `semver: ~7.5.0` (patches available in 7.5.x, minors beyond): `--apply --target patch` wrote `~7.5.4`; before the fix it wrote `~7.8.5`.