### PR TITLE
fix: skip npm: aliases and git/tarball URL specifiers

### DIFF
--- a/src/features/upgrade/package-detector.ts
+++ b/src/features/upgrade/package-detector.ts
@@ -310,11 +310,11 @@ export class PackageDetector {
         dep = catalogEntry
       }
 
-      if (this.isWorkspaceReference(dep.version)) {
+      if (this.isNonRegistrySpecifier(dep.version)) {
         const key = `${dep.name}@${dep.version}`
         if (!seenWorkspaceRefs.has(key)) {
           seenWorkspaceRefs.add(key)
-          debugLog.info('PackageDetector', `skipping workspace ref: ${key}`)
+          debugLog.info('PackageDetector', `skipping non-registry specifier: ${key}`)
         }
         continue
       }
@@ -538,7 +538,13 @@ export class PackageDetector {
     )
   }
 
-  private isWorkspaceReference(version: string): boolean {
+  /**
+   * Specifiers that don't point at a plain registry range, so there is nothing to resolve or
+   * upgrade: workspace/file/link refs, git hosts and URLs, tarball URLs, and `npm:` aliases.
+   * An `npm:` alias in particular must never be looked up under its alias name — the packument
+   * for that name is a different (or nonexistent) package.
+   */
+  private isNonRegistrySpecifier(version: string): boolean {
     return (
       version.includes('workspace:') ||
       version === '*' ||
@@ -546,7 +552,12 @@ export class PackageDetector {
       version.startsWith('link:') ||
       version.startsWith('github:') ||
       version.startsWith('gitlab:') ||
-      version.startsWith('bitbucket:')
+      version.startsWith('bitbucket:') ||
+      version.startsWith('npm:') ||
+      version.startsWith('git:') ||
+      version.startsWith('git+') ||
+      version.startsWith('http:') ||
+      version.startsWith('https:')
     )
   }
 

--- a/test/unit/features/upgrade/package-detector.test.ts
+++ b/test/unit/features/upgrade/package-detector.test.ts
@@ -557,7 +557,7 @@ describe('PackageDetector edge paths', () => {
       expect(packages[0].catalogReferencedBy).toEqual(['/repo/packages/a/package.json'])
       const wsLogs = vi
         .mocked(debugLog.info)
-        .mock.calls.filter((call) => String(call[1]).includes('skipping workspace ref'))
+        .mock.calls.filter((call) => String(call[1]).includes('skipping non-registry specifier'))
       expect(wsLogs).toHaveLength(1)
       const ignoreLogs = vi
         .mocked(debugLog.info)
@@ -566,6 +566,40 @@ describe('PackageDetector edge paths', () => {
     } finally {
       vi.mocked(isPackageIgnored).mockImplementation(() => false)
     }
+  })
+
+  it('skips npm: aliases and git/tarball URL specifiers', async () => {
+    mocks.collectAllDependenciesAsync.mockResolvedValue([
+      // An alias must never be looked up under its alias name — 'my-fork' is not
+      // the packument that 'npm:real-pkg@^1.0.0' points at.
+      dep('my-fork', 'npm:real-pkg@^1.0.0'),
+      dep('from-git', 'git+https://github.com/user/repo.git'),
+      dep('from-git-proto', 'git://github.com/user/repo.git'),
+      dep('tarball', 'https://example.com/pkg-1.0.0.tgz'),
+      dep('insecure-tarball', 'http://example.com/pkg-1.0.0.tgz'),
+      dep('zod', '^3.0.0'),
+    ])
+    mocks.fetchPackageVersions.mockImplementation(
+      async (packageNames: string[], options: { onBatchReady: (batch: any[]) => void }) => {
+        expect(packageNames).toEqual(['zod'])
+        options.onBatchReady([
+          {
+            packageName: 'zod',
+            data: { latestVersion: '3.1.0', allVersions: ['3.1.0', '3.0.0'] },
+            completed: 1,
+            total: 1,
+            batchIndex: 0,
+            itemIndex: 0,
+          },
+        ])
+        return new Map([['zod', { latestVersion: '3.1.0', allVersions: ['3.1.0', '3.0.0'] }]])
+      }
+    )
+
+    const detector = new PackageDetector({ cwd: '/repo' })
+    const packages = await detector.getOutdatedPackages()
+
+    expect(packages.map((pkg) => pkg.name)).toEqual(['zod'])
   })
 
   it('sorts scoped packages before unscoped ones', async () => {


### PR DESCRIPTION
## Problem

`isWorkspaceReference` in the package detector skipped `workspace:`/`file:`/`link:`/`github:`/`gitlab:`/`bitbucket:`/`*` specifiers, but not:

- **`npm:` aliases** — `"my-fork": "npm:real-pkg@^1.0.0"` was looked up under its *alias name* on the registry, i.e. a different (or nonexistent) package.
- **`git:` / `git+…` / `http(s):` tarball URLs** — non-semver specifiers that could surface as bogus upgrade candidates and, if selected, be overwritten with a semver range.

## Fix

Renamed the check to `isNonRegistrySpecifier` (private, single call site) and extended it to cover `npm:`, `git:`, `git+`, `http:`, `https:`. Debug log message updated accordingly.

## Verification

- New unit test covering all five new specifier forms alongside a normal dep; full suite passes with the 100% coverage gate.
- E2E: a scratch project with `"my-semver": "npm:semver@~7.5.0"` and `"chalk": "^5.0.0"` now reports only `chalk` in `--json`; before, the alias was queried against the registry under `my-semver`.