### PR TITLE
fix(coverage): restore 100% — v8 ignore block form for unreachable placeholders

### DIFF
--- a/src/app/interactive-ui.ts
+++ b/src/app/interactive-ui.ts
@@ -176,10 +176,14 @@ export class InteractiveUI {
     console.log(this.renderer.renderConfirmation(choices))
 
     return new Promise((resolve) => {
-      // Replaced synchronously below before any keypress can invoke it.
-      let cleanupConfirmationSession = /* v8 ignore next */ () => {
+      // Replaced synchronously below before any keypress can invoke it, so
+      // the placeholder body is unreachable. (The `v8 ignore next` form is
+      // not honored by coverage-v8 here; the block form is.)
+      /* v8 ignore start */
+      let cleanupConfirmationSession = () => {
         CursorUtils.show()
       }
+      /* v8 ignore stop */
 
       const handleConfirm = (confirmed: boolean | null) => {
         cleanupConfirmationSession()

--- a/src/shared/terminal/terminal-input.ts
+++ b/src/shared/terminal/terminal-input.ts
@@ -67,8 +67,12 @@ export const TerminalInput = {
     return new Promise((resolve) => {
       process.stdout.write(prompt)
 
-      // Replaced synchronously below before any keypress can call finish().
-      let cleanup = /* v8 ignore next */ () => {}
+      // Replaced synchronously below before any keypress can call finish(),
+      // so the placeholder body is unreachable. (The `v8 ignore next` form
+      // is not honored by coverage-v8 here; the block form is.)
+      /* v8 ignore start */
+      let cleanup = () => {}
+      /* v8 ignore stop */
       const finish = (value: boolean) => {
         cleanup()
         process.stdout.write('\n')


### PR DESCRIPTION
## Problem
CI fails the 100% coverage ratchet:
```
Functions  : 99.73% (766/768)
Statements : 99.97% ; Lines : 99.97%
```
Two never-called placeholder arrows — `cleanupConfirmationSession` in `interactive-ui.ts` and `cleanup` in `terminal-input.ts` — are reassigned synchronously before any keypress can invoke them, so their bodies are genuinely unreachable. They were annotated with an **inline** `/* v8 ignore next */`, which `@vitest/coverage-v8@4.1.9` no longer honors (the hint must sit on its own line, and even the `next`/`next N` form proved unreliable here).

## Fix
Switch both to the `/* v8 ignore start */ … /* v8 ignore stop */` block form already used successfully a few lines below in `interactive-ui.ts` (`confirmEmergencyCleanup`). No behavior change; restores **100% on all four metrics** (766/766 functions).

## Note
Pre-existing on `main` (introduced in #79, surfaced by a later coverage-v8 bump) — not related to the website branch, hence its own PR. Once merged, rebasing #88 clears its red CI too.