### PR TITLE
feat: hill-climb concurrency controller for slow links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Total downloads](https://img.shields.io/npm/dt/inup?style=for-the-badge&color=informational)](https://www.npmjs.com/package/inup)
 [![CI](https://img.shields.io/github/actions/workflow/status/donfear/inup/ci.yml?branch=main&style=for-the-badge&label=CI)](https://github.com/donfear/inup/actions/workflows/ci.yml)
 <!-- TEST-BADGES:START -->
-[![Tests](https://img.shields.io/badge/tests-1200_passing-brightgreen?style=for-the-badge&logo=vitest&logoColor=white)](https://github.com/donfear/inup/actions/workflows/ci.yml)
+[![Tests](https://img.shields.io/badge/tests-1213_passing-brightgreen?style=for-the-badge&logo=vitest&logoColor=white)](https://github.com/donfear/inup/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen?style=for-the-badge)](https://github.com/donfear/inup/actions/workflows/ci.yml)
 <!-- TEST-BADGES:END -->
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://github.com/donfear/inup/blob/main/LICENSE)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Total downloads](https://img.shields.io/npm/dt/inup?style=for-the-badge&color=informational)](https://www.npmjs.com/package/inup)
 [![CI](https://img.shields.io/github/actions/workflow/status/donfear/inup/ci.yml?branch=main&style=for-the-badge&label=CI)](https://github.com/donfear/inup/actions/workflows/ci.yml)
 <!-- TEST-BADGES:START -->
-[![Tests](https://img.shields.io/badge/tests-1108_passing-brightgreen?style=for-the-badge&logo=vitest&logoColor=white)](https://github.com/donfear/inup/actions/workflows/ci.yml)
+[![Tests](https://img.shields.io/badge/tests-1200_passing-brightgreen?style=for-the-badge&logo=vitest&logoColor=white)](https://github.com/donfear/inup/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen?style=for-the-badge)](https://github.com/donfear/inup/actions/workflows/ci.yml)
 <!-- TEST-BADGES:END -->
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://github.com/donfear/inup/blob/main/LICENSE)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ bun add -g inup
 
 Run `inup` in any project — it scans for outdated dependencies and lets you pick what to upgrade.
 
+> Requires Node 22.19+. Yes, an upgrade tool that asks you to upgrade first — we practice what we preach.
+
 ## Why inup?
 
 The picker does more than `outdated` — every capability is a keystroke away:

--- a/docs/rnd/hill-climb-concurrency.md
+++ b/docs/rnd/hill-climb-concurrency.md
@@ -72,6 +72,26 @@ Prereqs: `pnpm build`; a target project with 100+ unique dependencies.
 | all arms | `failed` count | 0 |
 | sanity | hillclimb ≈ best fixed arm per condition | fixed4 when throttled, fixed24 when fast |
 
+## Review hardening (adversarial pass, 2026-07-21)
+
+- Regime check is cache-mix-safe: both the persisted `baselineLatencyMs` and
+  the live comparison use FULL-fetch latency only (304s are fast on any link
+  and used to be able to fake a regime change in either direction). All-304
+  runs persist no baseline; validation that cannot gather 8 full fetches in
+  2 windows gives up and trusts the learned limit.
+- Validation survives errorful windows (soft-down applies, check continues);
+  a stale pre-error revert point can no longer cause multi-slot jumps.
+- Windows with a non-advancing clock (`Date.now()` is not monotonic) or
+  straddling a hard-down are discarded, never measured. Error windows
+  soft-decrease regardless of timing.
+- Profile `sampleCount` counts successes only; config writes are atomic
+  (write-then-rename); future `updatedAt` cannot defeat expiry.
+- `slowNetwork` now actually reaches the TUI (the runner dropped it), and the
+  loading-line hint is dropped before it can wrap a narrow terminal.
+- Experiment kit: ETag cache dir resolved via env-paths (the hardcoded path
+  made "cold" runs silently warm), priming run no longer writes a profile,
+  analyzer uses argparse.
+
 ## Known limitations / follow-ups
 
 - One global profile, not keyed by registry origin (VPN/private registries

--- a/docs/rnd/hill-climb-concurrency.md
+++ b/docs/rnd/hill-climb-concurrency.md
@@ -1,0 +1,84 @@
+# R&D: slow-start + hill-climb registry concurrency
+
+Branch: `rnd/hill-climb-concurrency`. Status: implemented, experiment pending.
+
+## Problem
+
+On a slow-but-healthy connection the AIMD controller never backs off — it only
+reacts to 429/503 and network errors — so it pins concurrency at the pool
+ceiling (24) and splits a narrow pipe across 24 sockets. The user sees
+`Loading packages…` sit frozen. Latency was deliberately excluded from AIMD
+decisions after it caused oscillation on healthy links (npm's CDN jitters).
+
+## What this branch adds
+
+- **`HillClimbController`** (`src/shared/http/hill-climb-controller.ts`):
+  passive goodput measurement (completions/sec per 12-completion window) on the
+  requests we already make — zero probes, zero extra traffic. Slow-start
+  doubling from 4 while a doubling buys ≥25%, ±1 hill-climb to the goodput
+  knee, HOLD with asymmetric hysteresis, occasional upward re-probes.
+  Congestion/retry semantics inherited from AIMD unchanged. Latency decides
+  nothing except the start-of-run regime check (3× baseline AND ≥500ms).
+- **Learned `NetworkProfile`** persisted in the user config (7-day expiry):
+  the next run starts at the learned limit as a *hypothesis* — validated
+  against live latency; a changed network resets to cold start. Runs too small
+  for the controller still use the learned limit as their fixed start.
+- **`--concurrency N` / `.inuprc "concurrency"`**: manual pin, disables all
+  adaptation. Precedence: flag > .inuprc > learned profile > cold default.
+- **UI**: loading line shows `— slow connection, reduced parallelism`;
+  performance modal (`p`) shows controller arm, state, and last goodput.
+
+Env toggles (all captured in perf logs): `INUP_CONTROLLER=aimd|hillclimb`
+(arm selector, default hillclimb), `INUP_NET_PROFILE=0` (disable profile
+read+write), `INUP_ADAPTIVE=0` (fixed limit, legacy).
+
+## Experiment protocol
+
+Prereqs: `pnpm build`; a target project with 100+ unique dependencies.
+
+1. **Throttle the link** (system-wide — undici connects directly, an HTTP
+   proxy would not be honored):
+   - Network Link Conditioner (Xcode "Additional Tools" dmg → prefpane).
+     Custom profile "inup-slow": 1 Mbps down / 256 kbps up / 150 ms delay /
+     0.5% loss. Also test the built-in "3G" profile.
+   - Scriptable alternative:
+     `sudo dnctl pipe 1 config bw 1Mbit/s delay 150` plus a pf rule routing
+     port-443 traffic through pipe 1.
+2. **Run the arms, interleaved** (5 reps each of aimd / hillclimb /
+   fixed 4 / 10 / 24), cold and warm ETag cache:
+
+   ```sh
+   scripts/hill-climb-experiment.sh ~/path/to/big-project 5 cold
+   scripts/hill-climb-experiment.sh ~/path/to/big-project 5 warm
+   ```
+
+3. **Repeat unthrottled** (fast-link regression check).
+4. **Persistence run** (separate, throttled, without `INUP_NET_PROFILE=0`):
+   run twice throttled — the second run must start at the learned limit —
+   then once unthrottled — the regime check must reset and re-climb.
+5. **Analyze**: `python3 scripts/analyze-hill-climb.py .inup-perf`
+   (use `--since <ISO>` to scope to today's runs).
+
+## Success criteria
+
+| Condition | Metric | Target vs `aimd` arm |
+| --- | --- | --- |
+| throttled, cold | `firstBatch` | ≥30% faster |
+| throttled, cold | pkg latency p95 | ≥2× lower |
+| throttled, cold | `registryFetch` | ≤ +10% (expect equal or better) |
+| throttled | settled limit | ≤ 8 |
+| fast link | `registryFetch` | within ±5% |
+| fast link | ramp | limit 24 within ≤3 ticks, zero down decisions |
+| all arms | `failed` count | 0 |
+| sanity | hillclimb ≈ best fixed arm per condition | fixed4 when throttled, fixed24 when fast |
+
+## Known limitations / follow-ups
+
+- One global profile, not keyed by registry origin (VPN/private registries
+  share it).
+- The `npm install` phase is `spawnSync` in the package manager — this work
+  does not touch it; a frozen spinner during install is a separate fix
+  (async spawn + live progress).
+- `ControlTick` exists in two structural copies
+  (`src/shared/http/adaptive-controller.ts` and `src/features/debug/types.ts`);
+  edit both.

--- a/scripts/analyze-hill-climb.py
+++ b/scripts/analyze-hill-climb.py
@@ -9,9 +9,9 @@ the settled concurrency limit, and failure counts.
 Usage: python3 scripts/analyze-hill-climb.py [.inup-perf] [--since ISO8601]
 """
 
+import argparse
 import json
 import statistics
-import sys
 from pathlib import Path
 
 
@@ -32,12 +32,12 @@ def pct(values: list[float], p: float) -> float:
 
 
 def main() -> None:
-    args = [a for a in sys.argv[1:] if not a.startswith("--")]
-    perf_dir = Path(args[0]) if args else Path(".inup-perf")
-    since = None
-    for i, a in enumerate(sys.argv[1:]):
-        if a == "--since":
-            since = sys.argv[1:][i + 1]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("perf_dir", nargs="?", default=".inup-perf", type=Path)
+    parser.add_argument("--since", help="only include runs at or after this ISO8601 timestamp")
+    parsed = parser.parse_args()
+    perf_dir = parsed.perf_dir
+    since = parsed.since
 
     groups: dict[str, list[dict]] = {}
     for path in sorted(perf_dir.glob("run-*.json")):

--- a/scripts/analyze-hill-climb.py
+++ b/scripts/analyze-hill-climb.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Summarize hill-climb A/B perf runs written by scripts/hill-climb-experiment.sh.
+
+Groups .inup-perf run files by arm (controllerMode / pinnedConcurrency) and
+reports the metrics the experiment is judged on: time-to-first-batch (the UX
+complaint), total registry-fetch time, wall time, per-package latency p50/p95,
+the settled concurrency limit, and failure counts.
+
+Usage: python3 scripts/analyze-hill-climb.py [.inup-perf] [--since ISO8601]
+"""
+
+import json
+import statistics
+import sys
+from pathlib import Path
+
+
+def arm_of(record: dict) -> str:
+    cfg = record.get("config", {})
+    pinned = cfg.get("pinnedConcurrency")
+    if pinned is not None:
+        return f"fixed{pinned}"
+    return cfg.get("controllerMode") or "aimd"
+
+
+def pct(values: list[float], p: float) -> float:
+    if not values:
+        return float("nan")
+    ordered = sorted(values)
+    k = max(0, min(len(ordered) - 1, round(p * (len(ordered) - 1))))
+    return ordered[k]
+
+
+def main() -> None:
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    perf_dir = Path(args[0]) if args else Path(".inup-perf")
+    since = None
+    for i, a in enumerate(sys.argv[1:]):
+        if a == "--since":
+            since = sys.argv[1:][i + 1]
+
+    groups: dict[str, list[dict]] = {}
+    for path in sorted(perf_dir.glob("run-*.json")):
+        try:
+            record = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if since and record.get("timestamp", "") < since:
+            continue
+        groups.setdefault(arm_of(record), []).append(record)
+
+    if not groups:
+        print(f"no run files in {perf_dir}")
+        return
+
+    header = (
+        f"{'arm':<10} {'n':>3} {'firstBatch':>11} {'regFetch':>9} {'wall':>7} "
+        f"{'pkg p50':>8} {'pkg p95':>8} {'settle':>7} {'downs':>6} {'fail':>5}"
+    )
+    print(header)
+    print("-" * len(header))
+    for arm in sorted(groups):
+        records = groups[arm]
+        first = [r["snapshot"]["phases"].get("firstBatch") for r in records]
+        first = [v for v in first if v is not None]
+        fetch = [r["snapshot"]["phases"].get("registryFetch") for r in records]
+        fetch = [v for v in fetch if v is not None]
+        wall = [r.get("wallMs") for r in records if r.get("wallMs") is not None]
+        latencies = [
+            t["latencyMs"] for r in records for t in r["snapshot"].get("packageTimings", [])
+        ]
+        settles = [
+            r["snapshot"]["controlTicks"][-1]["limit"]
+            for r in records
+            if r["snapshot"].get("controlTicks")
+        ]
+        downs = sum(
+            1
+            for r in records
+            for t in r["snapshot"].get("controlTicks", [])
+            if t["reason"] in ("step-down", "revert", "soft-down", "hard-down")
+        )
+        failed = sum(r["snapshot"].get("counts", {}).get("failed", 0) for r in records)
+
+        fmt = lambda vals: f"{statistics.median(vals):.0f}" if vals else "—"
+        print(
+            f"{arm:<10} {len(records):>3} {fmt(first):>11} {fmt(fetch):>9} {fmt(wall):>7} "
+            f"{pct(latencies, 0.5):>8.0f} {pct(latencies, 0.95):>8.0f} "
+            f"{fmt(settles):>7} {downs:>6} {failed:>5}"
+        )
+    print("\nmedians per arm; latency percentiles pooled across runs. ms everywhere.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hill-climb-experiment.sh
+++ b/scripts/hill-climb-experiment.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# A/B experiment runner for the hill-climb concurrency controller (R&D).
+#
+# Runs interleaved arms against a target project and collects perf JSONs into
+# .inup-perf/ (in this repo). Interleaving A,B,A,B controls for time-varying
+# network and npm CDN cache warmth; blocking all A runs before all B runs would
+# confound arm with time.
+#
+# Arms:
+#   aimd       INUP_CONTROLLER=aimd        (current main behavior)
+#   hillclimb  default                     (this branch)
+#   fixed4     --concurrency 4             (fixed reference, slow-link floor-ish)
+#   fixed10    --concurrency 10            (legacy default reference)
+#   fixed24    --concurrency 24            (pool-ceiling reference)
+#
+# Usage:
+#   scripts/hill-climb-experiment.sh <target-project-dir> [reps=5] [cold|warm]
+#
+# cold: the per-user ETag cache is wiped before every run (every packument
+#       re-downloads). warm: one unmeasured priming run first, then measure —
+#       the common real-world case, dominated by 304 revalidations.
+#
+# Throttle the link with Network Link Conditioner (or dummynet) around this
+# script; see docs/rnd/hill-climb-concurrency.md for profiles and analysis.
+
+set -euo pipefail
+
+TARGET_DIR=${1:?usage: hill-climb-experiment.sh <target-project-dir> [reps] [cold|warm]}
+REPS=${2:-5}
+CACHE_MODE=${3:-cold}
+
+REPO_DIR=$(cd "$(dirname "$0")/.." && pwd)
+PERF_DIR="$REPO_DIR/.inup-perf"
+CLI="$REPO_DIR/dist/cli.js"
+ETAG_CACHE="$HOME/Library/Caches/inup/etag-cache"
+
+[ -f "$CLI" ] || { echo "dist/cli.js missing — run 'pnpm build' first" >&2; exit 1; }
+
+ARMS=(aimd hillclimb fixed4 fixed10 fixed24)
+
+run_arm() {
+  local arm=$1
+  local args=(--check --dir "$TARGET_DIR")
+  local env=(INUP_PERF=1 "INUP_PERF_DIR=$PERF_DIR" INUP_NET_PROFILE=0)
+  case "$arm" in
+    aimd) env+=(INUP_CONTROLLER=aimd) ;;
+    hillclimb) ;;
+    fixed4) args+=(--concurrency 4) ;;
+    fixed10) args+=(--concurrency 10) ;;
+    fixed24) args+=(--concurrency 24) ;;
+  esac
+  if [ "$CACHE_MODE" = cold ]; then
+    rm -rf "$ETAG_CACHE"
+  fi
+  # --check exits 1 when updates exist — that is the expected outcome, not a failure.
+  env "${env[@]}" node "$CLI" "${args[@]}" >/dev/null 2>&1 || true
+}
+
+if [ "$CACHE_MODE" = warm ]; then
+  echo "priming ETag cache..."
+  node "$CLI" --check --dir "$TARGET_DIR" >/dev/null 2>&1 || true
+fi
+
+for rep in $(seq 1 "$REPS"); do
+  for arm in "${ARMS[@]}"; do
+    echo "rep $rep/$REPS  arm=$arm  cache=$CACHE_MODE"
+    run_arm "$arm"
+  done
+done
+
+echo "done — analyze with: python3 scripts/analyze-hill-climb.py $PERF_DIR"

--- a/scripts/hill-climb-experiment.sh
+++ b/scripts/hill-climb-experiment.sh
@@ -32,9 +32,17 @@ CACHE_MODE=${3:-cold}
 REPO_DIR=$(cd "$(dirname "$0")/.." && pwd)
 PERF_DIR="$REPO_DIR/.inup-perf"
 CLI="$REPO_DIR/dist/cli.js"
-ETAG_CACHE="$HOME/Library/Caches/inup/etag-cache"
 
 [ -f "$CLI" ] || { echo "dist/cli.js missing — run 'pnpm build' first" >&2; exit 1; }
+
+# Resolve the ETag cache dir through env-paths itself — the only source of
+# truth (it appends a "-nodejs" suffix; hardcoding the path once made every
+# "cold" rep silently warm because rm -rf deleted a directory that never
+# existed).
+ETAG_CACHE=$(cd "$REPO_DIR" && node --input-type=module -e \
+  "import envPaths from 'env-paths'; console.log(envPaths('inup').cache)")/etag-cache
+[ -n "$ETAG_CACHE" ] || { echo "failed to resolve the ETag cache dir" >&2; exit 1; }
+echo "ETag cache: $ETAG_CACHE"
 
 ARMS=(aimd hillclimb fixed4 fixed10 fixed24)
 
@@ -58,7 +66,9 @@ run_arm() {
 
 if [ "$CACHE_MODE" = warm ]; then
   echo "priming ETag cache..."
-  node "$CLI" --check --dir "$TARGET_DIR" >/dev/null 2>&1 || true
+  # INUP_NET_PROFILE=0 here too: a priming run on a throttled link must not
+  # persist a slow-link profile into the user's real config for the next week.
+  INUP_NET_PROFILE=0 node "$CLI" --check --dir "$TARGET_DIR" >/dev/null 2>&1 || true
 fi
 
 for rep in $(seq 1 "$REPS"); do

--- a/src/app/upgrade-runner.ts
+++ b/src/app/upgrade-runner.ts
@@ -69,13 +69,14 @@ export class UpgradeRunner {
       let previousSelections: Map<string, 'none' | 'range' | 'latest'> | undefined
 
       const selectionPromise = new Promise<PackageUpgradeChoice[]>((resolve, reject) => {
+        // The UI holds a reference to `progress`, so updates must mutate it in
+        // place — and copy EVERY field (a field-by-field copy silently dropped
+        // slowNetwork once).
+        const syncProgress = (next: PackageLoadProgress) => Object.assign(progress, next)
+
         const streamPromise = this.detector.streamOutdatedPackages((event) => {
           if (event.type === 'initial') {
-            progress.discovered = event.payload.progress.discovered
-            progress.resolved = event.payload.progress.resolved
-            progress.total = event.payload.progress.total
-            progress.failed = event.payload.progress.failed
-            progress.isLoading = event.payload.progress.isLoading
+            syncProgress(event.payload.progress)
 
             selectionStates = []
 
@@ -91,11 +92,7 @@ export class UpgradeRunner {
             latestPackages = latestPackages
               .filter((pkg) => !event.payload.batch.some((item) => item.packageName === pkg.name))
               .concat(event.payload.batch.flatMap((item) => item.packageInfo))
-            progress.discovered = event.payload.progress.discovered
-            progress.resolved = event.payload.progress.resolved
-            progress.total = event.payload.progress.total
-            progress.failed = event.payload.progress.failed
-            progress.isLoading = event.payload.progress.isLoading
+            syncProgress(event.payload.progress)
             performanceTracker.mark('firstBatch')
             this.ui.appendOutdatedBatchToSelectionStates(
               selectionStates,
@@ -107,11 +104,7 @@ export class UpgradeRunner {
 
           if (event.type === 'complete') {
             latestPackages = event.payload.packages
-            progress.discovered = event.payload.progress.discovered
-            progress.resolved = event.payload.progress.resolved
-            progress.total = event.payload.progress.total
-            progress.failed = event.payload.progress.failed
-            progress.isLoading = event.payload.progress.isLoading
+            syncProgress(event.payload.progress)
             performanceTracker.mark('firstBatch')
             performanceTracker.mark('allLoaded')
             if (isPerfLoggingEnabled()) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk'
 import { Command } from 'commander'
 import { HeadlessRunner } from './features/headless'
 import { UpgradeRunner } from './index'
-import { loadProjectConfig, PACKAGE_NAME, PACKAGE_VERSION } from './shared/config'
+import { loadProjectConfig, PACKAGE_NAME, PACKAGE_VERSION, POOL_CONNECTIONS } from './shared/config'
 import { enableDebugLogging } from './shared/debug-logger'
 import { getGitWorkingTreeState } from './shared/git'
 import { loadInupLocalEnv } from './shared/local-env'
@@ -33,6 +33,7 @@ export interface CliOptions {
   check?: boolean
   apply?: boolean
   target?: string
+  concurrency?: string
 }
 
 export async function runCli(options: CliOptions): Promise<void> {
@@ -100,6 +101,21 @@ export async function runCli(options: CliOptions): Promise<void> {
     process.exit(1)
   }
 
+  let concurrency: number | undefined
+  if (options.concurrency !== undefined) {
+    const parsed = Number(options.concurrency)
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > POOL_CONNECTIONS) {
+      console.error(chalk.red(`Invalid concurrency: ${options.concurrency}`))
+      console.error(
+        chalk.yellow(
+          `Expected an integer between 1 and ${POOL_CONNECTIONS}, for example: --concurrency 4`
+        )
+      )
+      process.exit(1)
+    }
+    concurrency = parsed
+  }
+
   // Check for updates in the background (non-blocking). Interactive only — keeps headless stdout
   // clean and avoids a lingering fetch handle in CI.
   const updateCheckPromise = interactive
@@ -130,9 +146,13 @@ export async function runCli(options: CliOptions): Promise<void> {
       projectConfig.showOptionalDependencyVulnerabilities ?? false,
     debug: options.debug || process.env.INUP_DEBUG === '1',
     saveExact: options.saveExact ?? false,
-    // Adaptive concurrency defaults ON; it's an internal/dev toggle with no public
-    // flag. Set INUP_ADAPTIVE=0 to disable (e.g. for A/B perf comparisons).
+    // Adaptive concurrency defaults ON; INUP_ADAPTIVE=0 disables it (fixed
+    // limit, A/B baseline). Related dev toggles read further down the stack:
+    // INUP_CONTROLLER=aimd|hillclimb picks the controller arm and
+    // INUP_NET_PROFILE=0 disables learned-profile persistence.
     adaptive: process.env.INUP_ADAPTIVE !== '0',
+    // Pinned parallelism: flag > .inuprc; undefined lets the controller adapt.
+    concurrency: concurrency ?? projectConfig.concurrency,
   }
 
   // Non-interactive (piped / CI / --json / --check) routes to the read-only headless feature;
@@ -195,6 +215,10 @@ program
   .option('--debug', 'write verbose debug log to /tmp/inup-debug-YYYY-MM-DD.log')
   .option('--no-color', 'disable colored output (also respects NO_COLOR / FORCE_COLOR)')
   .option('--save-exact', 'write exact versions instead of preserving the range prefix (^/~)')
+  .option(
+    '--concurrency <n>',
+    'pin registry-fetch parallelism (1-24) and disable adaptive ramping — for slow or metered connections'
+  )
   .option('--json', 'print a machine-readable JSON report and exit (non-interactive, read-only)')
   .option('-c, --check', 'exit non-zero if updates exist, without writing (for CI; read-only)')
   .option(

--- a/src/features/debug/perf-logger.ts
+++ b/src/features/debug/perf-logger.ts
@@ -67,6 +67,8 @@ export function isPerfLoggingEnabled(): boolean {
 export function perfEnv(): Record<string, string | undefined> {
   return {
     INUP_ADAPTIVE: process.env.INUP_ADAPTIVE,
+    INUP_CONTROLLER: process.env.INUP_CONTROLLER,
+    INUP_NET_PROFILE: process.env.INUP_NET_PROFILE,
     INUP_PERF: process.env.INUP_PERF,
     INUP_DEBUG: process.env.INUP_DEBUG,
     CI: process.env.CI,

--- a/src/features/debug/perf-logger.ts
+++ b/src/features/debug/perf-logger.ts
@@ -1,6 +1,7 @@
 import { appendFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { basename, isAbsolute, join, resolve } from 'node:path'
 import { DEFAULT_TUNING } from '../../shared/http/adaptive-controller'
+import { HILL_CLIMB_TUNING } from '../../shared/http/hill-climb-controller'
 import type { PerformanceSnapshot } from './types'
 
 /**
@@ -54,8 +55,10 @@ export interface PerfRunRecord {
   /** Wall-clock time for the whole tracked run, in ms. */
   wallMs: number | null
   config: PerfRunConfig
-  /** Tuning constants in effect when adaptive is on (for cross-run comparison). */
+  /** AIMD tuning constants in effect (for cross-run comparison). */
   tuning: typeof DEFAULT_TUNING
+  /** Hill-climb tuning constants in effect (which arm ran is in config.controllerMode). */
+  hillClimbTuning: typeof HILL_CLIMB_TUNING
   snapshot: PerformanceSnapshot
 }
 
@@ -122,6 +125,7 @@ export function writePerfLog(config: PerfRunConfig, snapshot: PerformanceSnapsho
       wallMs: snapshot.totalMs,
       config,
       tuning: DEFAULT_TUNING,
+      hillClimbTuning: HILL_CLIMB_TUNING,
       snapshot,
     }
 

--- a/src/features/debug/types.ts
+++ b/src/features/debug/types.ts
@@ -13,7 +13,24 @@ export interface BatchTiming {
   failedCount: number
 }
 
-export type ControlTickReason = 'up' | 'soft-down' | 'hard-down' | 'hold'
+export type ControlTickReason =
+  | 'up'
+  | 'soft-down'
+  | 'hard-down'
+  | 'hold'
+  | 'double'
+  | 'revert'
+  | 'step-down'
+  | 'probe-up'
+  | 'probe-reject'
+  | 'regime-reset'
+
+export type ConcurrencyControllerState =
+  | 'validating'
+  | 'slow-start'
+  | 'climb-up'
+  | 'climb-down'
+  | 'hold'
 
 /** One adaptive-concurrency control decision (separate channel from BatchTiming). */
 export interface ControlTick {
@@ -22,6 +39,9 @@ export interface ControlTick {
   ewmaMs: number
   retries: number
   reason: ControlTickReason
+  goodputRps?: number
+  state?: ConcurrencyControllerState
+  revalidatedRatio?: number
 }
 
 export interface PerformanceCounts {

--- a/src/features/debug/types.ts
+++ b/src/features/debug/types.ts
@@ -1,3 +1,5 @@
+import type { ControlTick } from '../../shared/http/controller-contract'
+
 export type PerformancePhase =
   | 'firstBatch'
   | 'allLoaded'
@@ -13,36 +15,14 @@ export interface BatchTiming {
   failedCount: number
 }
 
-export type ControlTickReason =
-  | 'up'
-  | 'soft-down'
-  | 'hard-down'
-  | 'hold'
-  | 'double'
-  | 'revert'
-  | 'step-down'
-  | 'probe-up'
-  | 'probe-reject'
-  | 'regime-reset'
-
-export type ConcurrencyControllerState =
-  | 'validating'
-  | 'slow-start'
-  | 'climb-up'
-  | 'climb-down'
-  | 'hold'
-
-/** One adaptive-concurrency control decision (separate channel from BatchTiming). */
-export interface ControlTick {
-  atMs: number
-  limit: number
-  ewmaMs: number
-  retries: number
-  reason: ControlTickReason
-  goodputRps?: number
-  state?: ConcurrencyControllerState
-  revalidatedRatio?: number
-}
+// One adaptive-concurrency control decision (separate channel from BatchTiming).
+// The canonical definitions live with the controllers; re-exported here so the
+// perf tracker/modal and the controllers can never drift apart structurally.
+export type {
+  ConcurrencyControllerState,
+  ControlTick,
+  ControlTickReason,
+} from '../../shared/http/controller-contract'
 
 export interface PerformanceCounts {
   packageJsonFiles?: number

--- a/src/features/interactive/modal/layout.ts
+++ b/src/features/interactive/modal/layout.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk'
+import { clamp } from '../../../shared/math'
 import { getVisualLength } from '../../../shared/terminal'
 import type { ModalSection } from './types'
 
@@ -10,7 +11,7 @@ export interface RenderModalOptions {
 }
 
 export function getModalWidth(terminalWidth: number, minWidth: number, maxWidth: number): number {
-  return Math.min(Math.max(minWidth, terminalWidth - 6), maxWidth)
+  return clamp(terminalWidth - 6, minWidth, maxWidth)
 }
 
 export function renderModalRow(padding: number, modalWidth: number, text: string): string {

--- a/src/features/interactive/renderer/help-modal.ts
+++ b/src/features/interactive/renderer/help-modal.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk'
+import { clamp } from '../../../shared/math'
 import { getHelpGroups } from '../keymap'
 import type { ModalRenderResult } from '../modal'
 import { getModalWidth, renderModalRow, renderModalSeparator } from '../modal'
@@ -44,7 +45,7 @@ export function renderHelpModal(
   const needsScroll = totalScrollableRows > availableForBody
   const visibleBodyRows = needsScroll ? Math.max(1, availableForBody - 1) : availableForBody
   const maxScroll = Math.max(0, totalScrollableRows - visibleBodyRows)
-  const clampedOffset = Math.min(Math.max(0, scrollOffset), maxScroll)
+  const clampedOffset = clamp(scrollOffset, 0, maxScroll)
   const visibleSlice = bodyRows.slice(clampedOffset, clampedOffset + visibleBodyRows)
 
   // ── Render ─────────────────────────────────────────────────────────────────

--- a/src/features/interactive/renderer/package-list/interface.ts
+++ b/src/features/interactive/renderer/package-list/interface.ts
@@ -210,10 +210,12 @@ export function renderInterface(
   if (loadingProgress?.isLoading) {
     const loadingLabel = `Loading packages... (${loadingProgress.resolved}/${loadingProgress.total} checked)`
     const failedLabel = loadingProgress.failed > 0 ? ` ${loadingProgress.failed} unavailable` : ''
+    const slowLabel = loadingProgress.slowNetwork ? ' — slow connection, reduced parallelism' : ''
     const loadingLine =
       '  ' +
       getThemeColor('textSecondary')(loadingLabel) +
-      (failedLabel ? chalk.yellow(failedLabel) : '')
+      (failedLabel ? chalk.yellow(failedLabel) : '') +
+      (slowLabel ? chalk.dim(slowLabel) : '')
     const loadingPadding = Math.max(0, terminalWidth - VersionUtils.getVisualLength(loadingLine))
     output.push(loadingLine + ' '.repeat(loadingPadding))
   }

--- a/src/features/interactive/renderer/package-list/interface.ts
+++ b/src/features/interactive/renderer/package-list/interface.ts
@@ -211,11 +211,18 @@ export function renderInterface(
     const loadingLabel = `Loading packages... (${loadingProgress.resolved}/${loadingProgress.total} checked)`
     const failedLabel = loadingProgress.failed > 0 ? ` ${loadingProgress.failed} unavailable` : ''
     const slowLabel = loadingProgress.slowNetwork ? ' — slow connection, reduced parallelism' : ''
-    const loadingLine =
+    let loadingLine =
       '  ' +
       getThemeColor('textSecondary')(loadingLabel) +
-      (failedLabel ? chalk.yellow(failedLabel) : '') +
-      (slowLabel ? chalk.dim(slowLabel) : '')
+      (failedLabel ? chalk.yellow(failedLabel) : '')
+    // The hint is informational only: drop it rather than overflow the row —
+    // padLineToWidth pads but never truncates, so an overflow wraps the frame.
+    if (
+      slowLabel &&
+      VersionUtils.getVisualLength(loadingLine) + slowLabel.length <= terminalWidth
+    ) {
+      loadingLine += chalk.dim(slowLabel)
+    }
     const loadingPadding = Math.max(0, terminalWidth - VersionUtils.getVisualLength(loadingLine))
     output.push(loadingLine + ' '.repeat(loadingPadding))
   }

--- a/src/features/interactive/renderer/performance-modal.ts
+++ b/src/features/interactive/renderer/performance-modal.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk'
+import { clamp } from '../../../shared/math'
 import type { PerformanceSnapshot } from '../../debug'
 import {
   getModalWidth,
@@ -154,7 +155,7 @@ export function renderPerformanceModal(
   const needsScroll = totalScrollableRows > availableForBody
   const visibleBodyRows = needsScroll ? Math.max(1, availableForBody - 1) : availableForBody
   const maxScroll = Math.max(0, totalScrollableRows - visibleBodyRows)
-  const clampedOffset = Math.min(Math.max(0, scrollOffset), maxScroll)
+  const clampedOffset = clamp(scrollOffset, 0, maxScroll)
   const visibleSlice = bodyRows.slice(clampedOffset, clampedOffset + visibleBodyRows)
 
   const lines: string[] = []

--- a/src/features/interactive/renderer/performance-modal.ts
+++ b/src/features/interactive/renderer/performance-modal.ts
@@ -88,12 +88,26 @@ function buildSections(snapshot: PerformanceSnapshot): {
     const limits = controlTicks.map((t) => t.limit)
     const finalTick = controlTicks[controlTicks.length - 1]
     const hardDowns = controlTicks.filter((t) => t.reason === 'hard-down').length
+    // Hill-climb ticks carry a state; plain AIMD ticks never do.
+    const isHillClimb = controlTicks.some((t) => t.state !== undefined)
+    bodyRows.push(labelValue('Controller', chalk.cyan(isHillClimb ? 'hillclimb' : 'aimd')))
     bodyRows.push(labelValue('Start limit', formatCount(controlTicks[0].limit)))
     bodyRows.push(labelValue('Peak limit', formatCount(Math.max(...limits))))
     bodyRows.push(labelValue('Final limit', formatCount(finalTick.limit)))
     bodyRows.push(labelValue('Final EWMA', formatMs(finalTick.ewmaMs)))
     bodyRows.push(labelValue('Control ticks', formatCount(controlTicks.length)))
     bodyRows.push(labelValue('Hard back-offs', formatCount(hardDowns)))
+    if (isHillClimb) {
+      bodyRows.push(labelValue('State', chalk.cyan(finalTick.state ?? '—')))
+      bodyRows.push(
+        labelValue(
+          'Last goodput',
+          finalTick.goodputRps !== undefined
+            ? chalk.yellow(`${finalTick.goodputRps}/s`)
+            : chalk.gray('—')
+        )
+      )
+    }
   } else {
     bodyRows.push(chalk.gray('  (fixed — adaptive off or run too small)'))
   }

--- a/src/features/upgrade/package-detector.ts
+++ b/src/features/upgrade/package-detector.ts
@@ -9,6 +9,7 @@ import {
   findPackageJson,
   readPackageJson,
 } from '../../shared/fs'
+import type { ControlTick } from '../../shared/http/adaptive-controller'
 import { isCatalogReference, PnpmCatalogs } from '../../shared/pnpm-catalogs'
 import { fetchPackageVersions, type PackageVersionData } from '../../shared/registry/npm-registry'
 import { ConsoleUtils } from '../../shared/terminal'
@@ -49,6 +50,8 @@ export class PackageDetector {
   /** INUP_NET_PROFILE=0 disables learned-profile read AND write (clean A/B runs). */
   private readonly profilePersistenceEnabled: boolean
   private readonly networkProfile: NetworkProfile | null
+  /** Latest control decision of the current run, for the slow-network hint. */
+  private lastControlTick: ControlTick | null = null
 
   constructor(options?: UpgradeOptions) {
     this.cwd = options?.cwd || process.cwd()
@@ -156,7 +159,10 @@ export class PackageDetector {
       onNetworkProfile: this.profilePersistenceEnabled
         ? (profile) => configManager.setNetworkProfile(profile)
         : undefined,
-      onControlTick: (tick) => performanceTracker.recordControlTick(tick),
+      onControlTick: (tick) => {
+        this.lastControlTick = tick
+        performanceTracker.recordControlTick(tick)
+      },
       onPackageTiming: isPerfLoggingEnabled()
         ? (name, latencyMs) => performanceTracker.recordPackageTiming({ name, latencyMs })
         : undefined,
@@ -498,7 +504,16 @@ export class PackageDetector {
       total,
       failed,
       isLoading,
+      slowNetwork: this.isSlowNetwork(),
     }
+  }
+
+  /** A settled-low limit or high latency EWMA reads as a slow connection. */
+  private isSlowNetwork(): boolean {
+    const tick = this.lastControlTick
+    if (!tick) return false
+    const settledLow = (tick.state === 'hold' || tick.state === 'climb-down') && tick.limit <= 6
+    return settledLow || tick.ewmaMs > 1000
   }
 
   private async findPackageJsonFilesWithTimeout(timeoutMs: number): Promise<string[]> {

--- a/src/features/upgrade/package-detector.ts
+++ b/src/features/upgrade/package-detector.ts
@@ -167,6 +167,9 @@ export class PackageDetector {
         ? (name, latencyMs) => performanceTracker.recordPackageTiming({ name, latencyMs })
         : undefined,
       onBatchReady: (batch) => {
+        // First-wins in the tracker; headless runs get the phase from here,
+        // the interactive runner's own mark becomes a no-op duplicate.
+        performanceTracker.mark('firstBatch')
         const batchStart = lastBatchEndAt
         let batchFailedCount = 0
         const batchItems: StreamOutdatedPackagesBatchItem[] = batch.map((batchItem) => {

--- a/src/features/upgrade/package-detector.ts
+++ b/src/features/upgrade/package-detector.ts
@@ -9,7 +9,7 @@ import {
   findPackageJson,
   readPackageJson,
 } from '../../shared/fs'
-import type { ControlTick } from '../../shared/http/adaptive-controller'
+import type { ControlTick } from '../../shared/http/controller-contract'
 import { isCatalogReference, PnpmCatalogs } from '../../shared/pnpm-catalogs'
 import { fetchPackageVersions, type PackageVersionData } from '../../shared/registry/npm-registry'
 import { ConsoleUtils } from '../../shared/terminal'
@@ -25,6 +25,12 @@ import type {
 } from '../../shared/types'
 import { findClosestMinorVersion } from '../../shared/versions'
 import { getPerformanceTracker, isPerfLoggingEnabled } from '../debug'
+
+// Slow-connection heuristic: the hill-climb controller (HILL_CLIMB_TUNING:
+// floor 3, ceil 24) settling at/below this limit in a down state, or a latency
+// EWMA above this, reads as a slow link for the loading UI.
+const SLOW_NETWORK_LIMIT_MAX = 6
+const SLOW_NETWORK_EWMA_MS = 1000
 
 interface PreparedDependencies {
   allDependencies: DependencyEntry[]
@@ -515,8 +521,9 @@ export class PackageDetector {
   private isSlowNetwork(): boolean {
     const tick = this.lastControlTick
     if (!tick) return false
-    const settledLow = (tick.state === 'hold' || tick.state === 'climb-down') && tick.limit <= 6
-    return settledLow || tick.ewmaMs > 1000
+    const settledLow =
+      (tick.state === 'hold' || tick.state === 'climb-down') && tick.limit <= SLOW_NETWORK_LIMIT_MAX
+    return settledLow || tick.ewmaMs > SLOW_NETWORK_EWMA_MS
   }
 
   private async findPackageJsonFilesWithTimeout(timeoutMs: number): Promise<string[]> {

--- a/src/features/upgrade/package-detector.ts
+++ b/src/features/upgrade/package-detector.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk'
 import * as semver from 'semver'
 import { isPackageIgnored, POOL_CONNECTIONS } from '../../shared/config'
+import { configManager } from '../../shared/config/user-config'
 import { debugLog } from '../../shared/debug-logger'
 import {
   collectAllDependenciesAsync,
@@ -13,6 +14,7 @@ import { fetchPackageVersions, type PackageVersionData } from '../../shared/regi
 import { ConsoleUtils } from '../../shared/terminal'
 import type {
   DependencyEntry,
+  NetworkProfile,
   PackageInfo,
   PackageLoadProgress,
   StreamOutdatedPackagesBatchItem,
@@ -41,6 +43,12 @@ export class PackageDetector {
   private readonly batchSize = 10
   private readonly maxConcurrency = 10
   private readonly adaptive: boolean
+  /** Pinned parallelism (flag / .inuprc); undefined lets the controller adapt. */
+  private readonly concurrency?: number
+  private readonly controllerMode: 'aimd' | 'hillclimb'
+  /** INUP_NET_PROFILE=0 disables learned-profile read AND write (clean A/B runs). */
+  private readonly profilePersistenceEnabled: boolean
+  private readonly networkProfile: NetworkProfile | null
 
   constructor(options?: UpgradeOptions) {
     this.cwd = options?.cwd || process.cwd()
@@ -49,6 +57,10 @@ export class PackageDetector {
     this.ignorePackages = options?.ignorePackages || []
     this.maxDepth = options?.maxDepth ?? 10
     this.adaptive = options?.adaptive ?? true
+    this.concurrency = options?.concurrency
+    this.controllerMode = process.env.INUP_CONTROLLER === 'aimd' ? 'aimd' : 'hillclimb'
+    this.profilePersistenceEnabled = process.env.INUP_NET_PROFILE !== '0'
+    this.networkProfile = this.profilePersistenceEnabled ? configManager.getNetworkProfile() : null
     this.packageJsonPath = findPackageJson(this.cwd)
     if (this.packageJsonPath) {
       this.packageJson = readPackageJson(this.packageJsonPath)
@@ -69,6 +81,10 @@ export class PackageDetector {
     maxConcurrency: number
     batchSize: number
     poolConnections: number
+    controllerMode: 'aimd' | 'hillclimb'
+    pinnedConcurrency: number | null
+    hadNetworkProfile: boolean
+    profileLearnedLimit: number | null
   } {
     return {
       cwd: this.cwd,
@@ -76,6 +92,10 @@ export class PackageDetector {
       maxConcurrency: this.maxConcurrency,
       batchSize: this.batchSize,
       poolConnections: POOL_CONNECTIONS,
+      controllerMode: this.controllerMode,
+      pinnedConcurrency: this.concurrency ?? null,
+      hadNetworkProfile: this.networkProfile !== null,
+      profileLearnedLimit: this.networkProfile?.learnedLimit ?? null,
     }
   }
 
@@ -130,6 +150,12 @@ export class PackageDetector {
       batchSize: this.batchSize,
       maxConcurrency: this.maxConcurrency,
       adaptive: this.adaptive,
+      concurrency: this.concurrency,
+      controllerMode: this.controllerMode,
+      networkProfile: this.networkProfile,
+      onNetworkProfile: this.profilePersistenceEnabled
+        ? (profile) => configManager.setNetworkProfile(profile)
+        : undefined,
       onControlTick: (tick) => performanceTracker.recordControlTick(tick),
       onPackageTiming: isPerfLoggingEnabled()
         ? (name, latencyMs) => performanceTracker.recordPackageTiming({ name, latencyMs })

--- a/src/shared/config/project-config.ts
+++ b/src/shared/config/project-config.ts
@@ -116,13 +116,22 @@ function normalizeConfig(config: InupProjectConfig): InupProjectConfig {
     normalized.showOptionalDependencyVulnerabilities = config.showOptionalDependencyVulnerabilities
   }
 
-  if (
-    typeof config.concurrency === 'number' &&
-    Number.isInteger(config.concurrency) &&
-    config.concurrency >= 1 &&
-    config.concurrency <= POOL_CONNECTIONS
-  ) {
-    normalized.concurrency = config.concurrency
+  if (config.concurrency !== undefined) {
+    if (
+      typeof config.concurrency === 'number' &&
+      Number.isInteger(config.concurrency) &&
+      config.concurrency >= 1 &&
+      config.concurrency <= POOL_CONNECTIONS
+    ) {
+      normalized.concurrency = config.concurrency
+    } else {
+      // Never drop this one silently: the user set it to protect a slow or
+      // metered link, and ignoring it would let the run adapt up to the pool
+      // ceiling — the exact opposite of their intent.
+      console.warn(
+        `Warning: ignoring invalid "concurrency" in project config (expected an integer 1..${POOL_CONNECTIONS}, got ${JSON.stringify(config.concurrency)})`
+      )
+    }
   }
 
   return normalized

--- a/src/shared/config/project-config.ts
+++ b/src/shared/config/project-config.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { POOL_CONNECTIONS } from './constants'
 import { PACKAGE_NAME } from './package-meta'
 
 /**
@@ -35,6 +36,13 @@ export interface InupProjectConfig {
    * Defaults to false so optional dependency risk stays hidden unless explicitly enabled.
    */
   showOptionalDependencyVulnerabilities?: boolean
+
+  /**
+   * Pin registry-fetch parallelism for this project (integer 1..24) and disable
+   * adaptive ramping. Escape hatch for known-slow networks; the --concurrency
+   * flag overrides this.
+   */
+  concurrency?: number
 }
 
 const CONFIG_FILES = [
@@ -106,6 +114,15 @@ function normalizeConfig(config: InupProjectConfig): InupProjectConfig {
 
   if (typeof config.showOptionalDependencyVulnerabilities === 'boolean') {
     normalized.showOptionalDependencyVulnerabilities = config.showOptionalDependencyVulnerabilities
+  }
+
+  if (
+    typeof config.concurrency === 'number' &&
+    Number.isInteger(config.concurrency) &&
+    config.concurrency >= 1 &&
+    config.concurrency <= POOL_CONNECTIONS
+  ) {
+    normalized.concurrency = config.concurrency
   }
 
   return normalized

--- a/src/shared/config/user-config.ts
+++ b/src/shared/config/user-config.ts
@@ -1,13 +1,19 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import envPaths from 'env-paths'
-import type { PersistedFilters } from '../types'
+import type { NetworkProfile, PersistedFilters } from '../types'
+import { POOL_CONNECTIONS } from './constants'
 import { PACKAGE_NAME } from './package-meta'
 
 interface ConfigFile {
   theme?: string
   filters?: PersistedFilters
+  networkProfile?: NetworkProfile
 }
+
+// Networks move (travel, VPN, tethering): an old profile is a misleading hint,
+// and re-learning costs one run's ramp-up — expiry is the cheap, safe choice.
+const NETWORK_PROFILE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
 
 class ConfigManager {
   private configDir: string
@@ -68,6 +74,41 @@ class ConfigManager {
   setFilters(filters: PersistedFilters): void {
     const config = this.readConfig()
     config.filters = filters
+    this.writeConfig(config)
+  }
+
+  /**
+   * The learned network profile, or null when absent, malformed (the file is
+   * user-editable), from an unknown schema, or older than 7 days.
+   */
+  getNetworkProfile(): NetworkProfile | null {
+    const profile = this.readConfig().networkProfile
+    if (profile?.schemaVersion !== 1) return null
+    if (
+      !Number.isInteger(profile.learnedLimit) ||
+      profile.learnedLimit < 1 ||
+      profile.learnedLimit > POOL_CONNECTIONS
+    ) {
+      return null
+    }
+    if (!Number.isFinite(profile.baselineLatencyMs) || profile.baselineLatencyMs < 0) return null
+    const updatedAt = Date.parse(profile.updatedAt)
+    if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > NETWORK_PROFILE_MAX_AGE_MS) {
+      return null
+    }
+    return profile
+  }
+
+  setNetworkProfile(profile: NetworkProfile): void {
+    const config = this.readConfig()
+    config.networkProfile = profile
+    this.writeConfig(config)
+  }
+
+  clearNetworkProfile(): void {
+    const config = this.readConfig()
+    if (config.networkProfile === undefined) return
+    config.networkProfile = undefined
     this.writeConfig(config)
   }
 }

--- a/src/shared/config/user-config.ts
+++ b/src/shared/config/user-config.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import envPaths from 'env-paths'
 import type { NetworkProfile, PersistedFilters } from '../types'
@@ -14,6 +14,9 @@ interface ConfigFile {
 // Networks move (travel, VPN, tethering): an old profile is a misleading hint,
 // and re-learning costs one run's ramp-up — expiry is the cheap, safe choice.
 const NETWORK_PROFILE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
+// A timestamp from the future (clock was ahead, then NTP-corrected; or a hand
+// edit) must not defeat expiry forever. Tolerate a day of skew, no more.
+const NETWORK_PROFILE_MAX_FUTURE_MS = 24 * 60 * 60 * 1000
 
 class ConfigManager {
   private configDir: string
@@ -49,7 +52,13 @@ class ConfigManager {
   private writeConfig(config: ConfigFile): void {
     try {
       this.ensureConfigDir()
-      writeFileSync(this.configPath, JSON.stringify(config, null, 2), 'utf-8')
+      // Write-then-rename: the learned network profile is now written
+      // automatically at the end of a run, so this file is written far more
+      // often than before — a crash mid-write must never leave truncated JSON
+      // that would silently erase the user's theme and filters on next write.
+      const tmpPath = `${this.configPath}.${process.pid}.tmp`
+      writeFileSync(tmpPath, JSON.stringify(config, null, 2), 'utf-8')
+      renameSync(tmpPath, this.configPath)
     } catch (error) {
       console.error('Error writing config:', error)
     }
@@ -93,9 +102,9 @@ class ConfigManager {
     }
     if (!Number.isFinite(profile.baselineLatencyMs) || profile.baselineLatencyMs < 0) return null
     const updatedAt = Date.parse(profile.updatedAt)
-    if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > NETWORK_PROFILE_MAX_AGE_MS) {
-      return null
-    }
+    const age = Date.now() - updatedAt
+    if (!Number.isFinite(age) || age > NETWORK_PROFILE_MAX_AGE_MS) return null
+    if (age < -NETWORK_PROFILE_MAX_FUTURE_MS) return null
     return profile
   }
 

--- a/src/shared/http/adaptive-controller.ts
+++ b/src/shared/http/adaptive-controller.ts
@@ -50,7 +50,26 @@ export const DEFAULT_TUNING: AdaptiveTuning = {
   ticksEveryCompletions: 6,
 }
 
-export type ControlTickReason = 'up' | 'soft-down' | 'hard-down' | 'hold'
+export type ControlTickReason =
+  | 'up'
+  | 'soft-down'
+  | 'hard-down'
+  | 'hold'
+  // Emitted by the hill-climb controller only:
+  | 'double'
+  | 'revert'
+  | 'step-down'
+  | 'probe-up'
+  | 'probe-reject'
+  | 'regime-reset'
+
+/** Hill-climb controller phase; AIMD has no phases and never sets it. */
+export type ConcurrencyControllerState =
+  | 'validating'
+  | 'slow-start'
+  | 'climb-up'
+  | 'climb-down'
+  | 'hold'
 
 export interface ControlTick {
   atMs: number
@@ -58,9 +77,33 @@ export interface ControlTick {
   ewmaMs: number
   retries: number
   reason: ControlTickReason
+  /** Window goodput (completions/sec); hill-climb controller only. */
+  goodputRps?: number
+  /** Controller phase after the decision; hill-climb controller only. */
+  state?: ConcurrencyControllerState
+  /** Share of ETag-304 revalidations in the window (0..1); hill-climb only. */
+  revalidatedRatio?: number
 }
 
 export type RequestOutcomeKind = 'success' | 'congested' | 'retryable' | 'transient'
+
+export interface RequestOutcomeMeta {
+  /** True when the response was an ETag 304 revalidation (tiny and fast even on a slow pipe). */
+  revalidated?: boolean
+}
+
+/**
+ * Contract shared by the concurrency controllers (AIMD and hill-climb): a pure
+ * decision function fed per-request outcomes, returning limit changes for the
+ * caller to apply to the semaphore.
+ */
+export interface ConcurrencyController {
+  getLimit(): number
+  record(kind: RequestOutcomeKind, latencyMs?: number, meta?: RequestOutcomeMeta): number | null
+  maybeTick(now?: number): number | null
+  /** Stop making decisions (run tail); optional — AIMD does not need it. */
+  freeze?(): void
+}
 
 const clamp = (value: number, lo: number, hi: number): number => Math.max(lo, Math.min(hi, value))
 

--- a/src/shared/http/adaptive-controller.ts
+++ b/src/shared/http/adaptive-controller.ts
@@ -23,6 +23,23 @@
  * limit. Real congestion shows up as 429, which we handle directly.
  */
 
+import { clamp, Ewma } from '../math'
+import type {
+  ConcurrencyController,
+  ControlTick,
+  ControlTickReason,
+  RequestOutcomeKind,
+} from './controller-contract'
+
+export type {
+  ConcurrencyController,
+  ConcurrencyControllerState,
+  ControlTick,
+  ControlTickReason,
+  RequestOutcomeKind,
+  RequestOutcomeMeta,
+} from './controller-contract'
+
 export interface AdaptiveTuning {
   /** Lower bound on the limit. */
   floor: number
@@ -50,71 +67,13 @@ export const DEFAULT_TUNING: AdaptiveTuning = {
   ticksEveryCompletions: 6,
 }
 
-export type ControlTickReason =
-  | 'up'
-  | 'soft-down'
-  | 'hard-down'
-  | 'hold'
-  // Emitted by the hill-climb controller only:
-  | 'double'
-  | 'revert'
-  | 'step-down'
-  | 'probe-up'
-  | 'probe-reject'
-  | 'regime-reset'
-
-/** Hill-climb controller phase; AIMD has no phases and never sets it. */
-export type ConcurrencyControllerState =
-  | 'validating'
-  | 'slow-start'
-  | 'climb-up'
-  | 'climb-down'
-  | 'hold'
-
-export interface ControlTick {
-  atMs: number
-  limit: number
-  ewmaMs: number
-  retries: number
-  reason: ControlTickReason
-  /** Window goodput (completions/sec); hill-climb controller only. */
-  goodputRps?: number
-  /** Controller phase after the decision; hill-climb controller only. */
-  state?: ConcurrencyControllerState
-  /** Share of ETag-304 revalidations in the window (0..1); hill-climb only. */
-  revalidatedRatio?: number
-}
-
-export type RequestOutcomeKind = 'success' | 'congested' | 'retryable' | 'transient'
-
-export interface RequestOutcomeMeta {
-  /** True when the response was an ETag 304 revalidation (tiny and fast even on a slow pipe). */
-  revalidated?: boolean
-}
-
-/**
- * Contract shared by the concurrency controllers (AIMD and hill-climb): a pure
- * decision function fed per-request outcomes, returning limit changes for the
- * caller to apply to the semaphore.
- */
-export interface ConcurrencyController {
-  getLimit(): number
-  record(kind: RequestOutcomeKind, latencyMs?: number, meta?: RequestOutcomeMeta): number | null
-  maybeTick(now?: number): number | null
-  /** Stop making decisions (run tail); optional — AIMD does not need it. */
-  freeze?(): void
-}
-
-const clamp = (value: number, lo: number, hi: number): number => Math.max(lo, Math.min(hi, value))
-
-export class AdaptiveController {
+export class AdaptiveController implements ConcurrencyController {
   private readonly tuning: AdaptiveTuning
   private limit: number
 
   // EWMA of successful single-attempt latency. Kept for instrumentation only
   // (the perf modal / logs); it does not drive concurrency decisions.
-  private ewmaMs = 0
-  private hasEwma = false
+  private readonly latencyEwma: Ewma
 
   private completionsSinceTick = 0
   private retriesSinceTick = 0
@@ -133,6 +92,7 @@ export class AdaptiveController {
     tuning: Partial<AdaptiveTuning> = {}
   ) {
     this.tuning = { ...DEFAULT_TUNING, ...tuning }
+    this.latencyEwma = new Ewma(this.tuning.ewmaAlpha)
     // Smart start: aim at the work size, clamped to [floor, ceil].
     this.limit = clamp(
       Math.min(this.tuning.ceil, packageCount),
@@ -161,7 +121,7 @@ export class AdaptiveController {
     this.completionsSinceTick++
 
     if (kind === 'success' && latencyMs !== undefined) {
-      this.sampleLatency(latencyMs)
+      this.latencyEwma.update(latencyMs)
       return null
     }
 
@@ -184,16 +144,6 @@ export class AdaptiveController {
       return null
     }
     return this.tick(now)
-  }
-
-  private sampleLatency(latencyMs: number): void {
-    if (!this.hasEwma) {
-      this.ewmaMs = latencyMs
-      this.hasEwma = true
-    } else {
-      const a = this.tuning.ewmaAlpha
-      this.ewmaMs = a * latencyMs + (1 - a) * this.ewmaMs
-    }
   }
 
   private applyHardDecrease(): number {
@@ -238,7 +188,7 @@ export class AdaptiveController {
     this.onTick?.({
       atMs: now,
       limit: this.limit,
-      ewmaMs: Math.round(this.ewmaMs),
+      ewmaMs: Math.round(this.latencyEwma.value),
       retries: this.retriesSinceTick,
       reason,
     })

--- a/src/shared/http/controller-contract.ts
+++ b/src/shared/http/controller-contract.ts
@@ -1,0 +1,59 @@
+/**
+ * Contract shared by the concurrency controllers (AIMD and hill-climb) and
+ * everything that observes them (registry wiring, perf tracker, perf modal).
+ * Pure types — no runtime code beyond what TypeScript erases.
+ */
+
+export type ControlTickReason =
+  | 'up'
+  | 'soft-down'
+  | 'hard-down'
+  | 'hold'
+  // Emitted by the hill-climb controller only:
+  | 'double'
+  | 'revert'
+  | 'step-down'
+  | 'probe-up'
+  | 'probe-reject'
+  | 'regime-reset'
+
+/** Hill-climb controller phase; AIMD has no phases and never sets it. */
+export type ConcurrencyControllerState =
+  | 'validating'
+  | 'slow-start'
+  | 'climb-up'
+  | 'climb-down'
+  | 'hold'
+
+export interface ControlTick {
+  atMs: number
+  limit: number
+  ewmaMs: number
+  retries: number
+  reason: ControlTickReason
+  /** Window goodput (completions/sec); hill-climb controller only. */
+  goodputRps?: number
+  /** Controller phase after the decision; hill-climb controller only. */
+  state?: ConcurrencyControllerState
+  /** Share of ETag-304 revalidations in the window (0..1); hill-climb only. */
+  revalidatedRatio?: number
+}
+
+export type RequestOutcomeKind = 'success' | 'congested' | 'retryable' | 'transient'
+
+export interface RequestOutcomeMeta {
+  /** True when the response was an ETag 304 revalidation (tiny and fast even on a slow pipe). */
+  revalidated?: boolean
+}
+
+/**
+ * A controller is a pure decision function fed per-request outcomes, returning
+ * limit changes for the caller to apply to the resizable semaphore.
+ */
+export interface ConcurrencyController {
+  getLimit(): number
+  record(kind: RequestOutcomeKind, latencyMs?: number, meta?: RequestOutcomeMeta): number | null
+  maybeTick(now?: number): number | null
+  /** Stop making decisions (run tail); optional — AIMD does not need it. */
+  freeze?(): void
+}

--- a/src/shared/http/hill-climb-controller.ts
+++ b/src/shared/http/hill-climb-controller.ts
@@ -80,8 +80,11 @@ export interface HillClimbTuning {
   validateAfterCompletions: number
   /** Live EWMA must exceed baseline × this AND the absolute floor below… */
   regimeWorseFactor: number
-  /** …this many ms, for the regime to count as changed. */
+  /** …this many ms, for the regime to count as changed for the worse. */
   regimeWorseMinMs: number
+  /** A better regime needs the same ratio AND at least this much absolute
+   * improvement — two fast states differing by a few ms are the same regime. */
+  regimeBetterMinDeltaMs: number
 }
 
 export const HILL_CLIMB_TUNING: HillClimbTuning = {
@@ -107,6 +110,7 @@ export const HILL_CLIMB_TUNING: HillClimbTuning = {
   validateAfterCompletions: 8,
   regimeWorseFactor: 3,
   regimeWorseMinMs: 500,
+  regimeBetterMinDeltaMs: 200,
 }
 
 /** Runs below this size cannot close two windows plus a tail — skip control. */
@@ -277,21 +281,30 @@ export class HillClimbController implements ConcurrencyController {
   }
 
   /** The one place latency decides anything: does the persisted profile still
-   * describe this network? A 3× AND ≥500ms bar is far above CDN variance. */
+   * describe this network? The check is symmetric. Worse (3× AND ≥500ms —
+   * far above CDN variance): the learned limit would strangle a slow link.
+   * Better (3× AND ≥200ms improvement): the learned limit would drag a fast
+   * link — from a profile the start is gated, so same-limit windows read as a
+   * plateau and the controller would climb DOWN, recovering only by probes.
+   * Either way the profile is from a different network: restart and re-learn. */
   private validateProfile(): number | null {
     this.validationRemaining--
     if (this.validationRemaining > 0) return null
     const t = this.tuning
     const baseline = this.profileBaselineMs ?? 0
     const worse = this.ewmaMs > Math.max(t.regimeWorseFactor * baseline, t.regimeWorseMinMs)
+    const better =
+      baseline - this.ewmaMs > t.regimeBetterMinDeltaMs &&
+      this.ewmaMs * t.regimeWorseFactor < baseline
     this.phase = 'slow-start'
-    if (!worse) {
-      // Regime matches (or improved — doubling will discover that): climb
-      // from the learned limit, gated from the first comparison on.
+    if (!worse && !better) {
+      // Same regime: climb from the learned limit, gated from here on.
       return null
     }
-    // The profile is from a different network. Restart low and re-learn.
     this.limit = clamp(t.coldStart, t.floor, t.ceil)
+    // On a better regime the cold start may double blindly (the link is fast;
+    // a wrong guess costs one window). On a worse one, stay gated.
+    this.blindDoubleArmed = better
     this.emit('regime-reset')
     return this.limit
   }

--- a/src/shared/http/hill-climb-controller.ts
+++ b/src/shared/http/hill-climb-controller.ts
@@ -1,0 +1,521 @@
+/**
+ * Slow-start + hill-climb concurrency controller for slow links.
+ *
+ * The AIMD controller next door backs off only on real error signals (429/503,
+ * transient failures). That is correct for congestion but blind to a slow yet
+ * healthy pipe: it ramps to the ceiling and splits a narrow connection across
+ * 24 sockets. This controller instead measures *goodput* — completions per
+ * second over a window of requests we make anyway — and climbs the concurrency
+ * hill toward the knee of the curve:
+ *
+ *  - SLOW_START: double the limit while a doubling still buys ≥25% goodput.
+ *  - CLIMB_UP:   +1 per window while each step still buys ≥5%.
+ *  - CLIMB_DOWN: when goodput is flat, fewer sockets do the same work — step
+ *                −1 per window until throughput actually drops, then back up.
+ *  - HOLD:       sit at the knee; step down only after two consecutive
+ *                degraded windows; probe +1 occasionally to catch recovery.
+ *  - VALIDATING: when starting from a persisted profile, confirm the network
+ *                regime still matches before trusting the learned limit.
+ *
+ * Per-request latency NEVER drives a decision (the documented AIMD oscillation
+ * failure was reacting to CDN latency variance). Latency is used exactly once:
+ * the start-of-run regime check against a persisted baseline, with a 3× AND
+ * ≥500ms bar that CDN jitter cannot clear. Decisions compare windowed goodput
+ * with asymmetric hysteresis (+5% to move up, sustained −10% to move down in
+ * HOLD), and steps are ±1 — worst-case oscillation amplitude is one slot.
+ *
+ * Error semantics are inherited from AIMD unchanged: congestion (429/503)
+ * hard-halves the limit immediately; retryable errors in a window soft-decrease
+ * (×0.7) at the tick and suppress any increase.
+ *
+ * Windows with a very different ETag-304 share are not compared: a 304 is
+ * header-sized and fast even on a slow pipe, so a cache-mix shift would fake a
+ * goodput change. The comparison baseline still rolls forward so decisions
+ * resume on the next comparable window.
+ */
+
+import { POOL_CONNECTIONS } from '../config/constants'
+import type { NetworkProfile } from '../types/domain'
+import type {
+  ConcurrencyController,
+  ConcurrencyControllerState,
+  ControlTick,
+  ControlTickReason,
+  RequestOutcomeKind,
+  RequestOutcomeMeta,
+} from './adaptive-controller'
+
+export interface HillClimbTuning {
+  /** Lower bound on the limit. */
+  floor: number
+  /** Upper bound on the limit (kept == the pool's connection count). */
+  ceil: number
+  /** Slow-start seed when there is no (valid) persisted profile. */
+  coldStart: number
+  /** Completions per goodput window; also the control-tick cadence. */
+  windowCompletions: number
+  /** Window-over-window gain that justifies another doubling. */
+  strongGainFactor: number
+  /** Minimum gain to accept any upward move (+1 step or probe). */
+  gainEpsilon: number
+  /** A down-step is kept only if goodput stayed at least this fraction. */
+  keepDownEpsilon: number
+  /** In HOLD, a window below this fraction of best counts as degraded. */
+  holdDegradeFactor: number
+  /** Consecutive degraded windows before HOLD steps down. */
+  holdDegradeWindows: number
+  /** Per-window decay of the best-goodput reference in HOLD. */
+  bestGoodputDecay: number
+  /** Healthy HOLD windows between upward probes. */
+  reprobeAfterWindows: number
+  /** Skip the decision when the 304 share shifted more than this between windows. */
+  revalidatedComparableDelta: number
+  /** EWMA smoothing for the latency instrumentation / regime check. */
+  ewmaAlpha: number
+  /** Multiplier on an error-driven soft decrease (AIMD semantics). */
+  softDecreaseFactor: number
+  /** Multiplier on a congestion-driven hard decrease (AIMD semantics). */
+  hardDecreaseFactor: number
+  /** Successes before the persisted profile is judged against live latency. */
+  validateAfterCompletions: number
+  /** Live EWMA must exceed baseline × this AND the absolute floor below… */
+  regimeWorseFactor: number
+  /** …this many ms, for the regime to count as changed. */
+  regimeWorseMinMs: number
+}
+
+export const HILL_CLIMB_TUNING: HillClimbTuning = {
+  // Below ~3 even a narrow pipe is underutilized (304s are header-sized).
+  floor: 3,
+  ceil: POOL_CONNECTIONS,
+  coldStart: 4,
+  // 12 completions average out npm CDN jitter within one window.
+  windowCompletions: 12,
+  strongGainFactor: 1.25,
+  gainEpsilon: 1.05,
+  // RTT-bound links lose ~1/L (≈4–13%) per removed slot → down-step rejected
+  // immediately; bandwidth-bound links are flat → the count-down proceeds.
+  keepDownEpsilon: 0.98,
+  holdDegradeFactor: 0.9,
+  holdDegradeWindows: 2,
+  bestGoodputDecay: 0.98,
+  reprobeAfterWindows: 6,
+  revalidatedComparableDelta: 0.3,
+  ewmaAlpha: 0.3,
+  softDecreaseFactor: 0.7,
+  hardDecreaseFactor: 0.5,
+  validateAfterCompletions: 8,
+  regimeWorseFactor: 3,
+  regimeWorseMinMs: 500,
+}
+
+/** Runs below this size cannot close two windows plus a tail — skip control. */
+const MIN_CONTROLLED_TOTAL = 30
+
+const clamp = (value: number, lo: number, hi: number): number => Math.max(lo, Math.min(hi, value))
+
+const round2 = (value: number): number => Math.round(value * 100) / 100
+
+export interface HillClimbOptions {
+  /** Persisted starting hypothesis; validated against live latency, never a cap. */
+  profile?: Pick<NetworkProfile, 'learnedLimit' | 'baselineLatencyMs'> | null
+  /** Sink for control decisions (perf modal / logs). */
+  onTick?: (tick: ControlTick) => void
+  /** Override the defaults (tests / experiments). */
+  tuning?: Partial<HillClimbTuning>
+  /** Timestamp the run started; anchors the first goodput window. */
+  startedAt?: number
+}
+
+export class HillClimbController implements ConcurrencyController {
+  private readonly tuning: HillClimbTuning
+  private readonly onTick?: (tick: ControlTick) => void
+
+  private limit: number
+  private phase: ConcurrencyControllerState
+  private frozen = false
+
+  // Latency EWMA: instrumentation plus the one-shot regime check — decisions
+  // never read it (see the class docblock).
+  private ewmaMs = 0
+  private hasEwma = false
+  private readonly profileBaselineMs: number | null = null
+  private validationRemaining = 0
+
+  private completionsSinceTick = 0
+  private retriesSinceTick = 0
+  private revalidatedSinceTick = 0
+  private totalCompletions = 0
+  private windowStartedAt: number
+  private windowIndex = 0
+  private lastHardDownWindow = Number.NEGATIVE_INFINITY
+
+  /** Goodput and 304-share of the last closed comparable-or-rolled window. */
+  private prevGoodput: number | null = null
+  private prevRatio: number | null = null
+  /** Cold start may double once without a baseline; any signal disarms it. */
+  private blindDoubleArmed = false
+  /** Limit before the last upward move, for a cheap revert. */
+  private limitBeforeIncrease: number | null = null
+
+  // HOLD bookkeeping.
+  private bestGoodput = 0
+  private badStreak = 0
+  private windowsSinceProbe = 0
+  private probePending = false
+  private preProbeLimit = 0
+  private probeBaseline = 0
+  private reachedHold = false
+
+  constructor(packageCount: number, options: HillClimbOptions = {}) {
+    this.tuning = { ...HILL_CLIMB_TUNING, ...options.tuning }
+    this.onTick = options.onTick
+    const t = this.tuning
+    const profile = options.profile ?? null
+    if (profile) {
+      this.limit = clamp(Math.round(profile.learnedLimit), t.floor, t.ceil)
+      this.phase = 'validating'
+      this.profileBaselineMs = profile.baselineLatencyMs
+      this.validationRemaining = t.validateAfterCompletions
+    } else {
+      this.limit = clamp(t.coldStart, t.floor, t.ceil)
+      this.phase = 'slow-start'
+      this.blindDoubleArmed = true
+    }
+    // Never more parallel than there is work.
+    this.limit = Math.min(this.limit, Math.max(1, packageCount))
+    this.windowStartedAt = options.startedAt ?? Date.now()
+  }
+
+  /** Whether the controller should even run; tiny runs are better off fixed. */
+  static shouldControl(packageCount: number): boolean {
+    return packageCount >= MIN_CONTROLLED_TOTAL
+  }
+
+  getLimit(): number {
+    return this.limit
+  }
+
+  getState(): ConcurrencyControllerState {
+    return this.phase
+  }
+
+  /** Stop making decisions for the run tail: fewer in-flight requests than the
+   * limit would read as a goodput collapse and poison the settled profile. */
+  freeze(): void {
+    this.frozen = true
+  }
+
+  /**
+   * Record a completed request. Returns a new limit to apply IMMEDIATELY on a
+   * congestion hard-decrease or a failed profile validation; otherwise null
+   * (the limit may still change at the next window tick).
+   */
+  record(kind: RequestOutcomeKind, latencyMs?: number, meta?: RequestOutcomeMeta): number | null {
+    this.completionsSinceTick++
+    this.totalCompletions++
+
+    if (kind === 'success') {
+      if (meta?.revalidated) this.revalidatedSinceTick++
+      if (latencyMs !== undefined) {
+        this.sampleLatency(latencyMs)
+        if (this.phase === 'validating') return this.validateProfile()
+      }
+      return null
+    }
+
+    this.retriesSinceTick++
+    if (kind === 'congested') {
+      return this.applyHardDecrease()
+    }
+    // retryable / transient: soft-decrease happens at the tick
+    return null
+  }
+
+  /**
+   * Call after each completion. Closes the goodput window when due and returns
+   * the new limit if the decision changed it; otherwise null.
+   */
+  maybeTick(now: number = Date.now()): number | null {
+    if (this.completionsSinceTick < this.tuning.windowCompletions) {
+      return null
+    }
+    if (this.frozen) {
+      this.resetWindow(now)
+      return null
+    }
+    return this.tick(now)
+  }
+
+  /**
+   * The learned network shape to persist, or null when this run settled
+   * nothing trustworthy (never held, too few samples, or congestion at the
+   * end — a mid-back-off limit is not a profile).
+   */
+  getSettledProfile(now: number = Date.now()): NetworkProfile | null {
+    if (!this.reachedHold) return null
+    if (this.totalCompletions < MIN_CONTROLLED_TOTAL) return null
+    if (this.windowIndex - this.lastHardDownWindow < 2) return null
+    return {
+      schemaVersion: 1,
+      learnedLimit: this.limit,
+      baselineLatencyMs: Math.round(this.ewmaMs),
+      baselineGoodputRps: round2(this.prevGoodput ?? 0),
+      sampleCount: this.totalCompletions,
+      updatedAt: new Date(now).toISOString(),
+    }
+  }
+
+  private sampleLatency(latencyMs: number): void {
+    if (!this.hasEwma) {
+      this.ewmaMs = latencyMs
+      this.hasEwma = true
+    } else {
+      const a = this.tuning.ewmaAlpha
+      this.ewmaMs = a * latencyMs + (1 - a) * this.ewmaMs
+    }
+  }
+
+  /** The one place latency decides anything: does the persisted profile still
+   * describe this network? A 3× AND ≥500ms bar is far above CDN variance. */
+  private validateProfile(): number | null {
+    this.validationRemaining--
+    if (this.validationRemaining > 0) return null
+    const t = this.tuning
+    const baseline = this.profileBaselineMs ?? 0
+    const worse = this.ewmaMs > Math.max(t.regimeWorseFactor * baseline, t.regimeWorseMinMs)
+    this.phase = 'slow-start'
+    if (!worse) {
+      // Regime matches (or improved — doubling will discover that): climb
+      // from the learned limit, gated from the first comparison on.
+      return null
+    }
+    // The profile is from a different network. Restart low and re-learn.
+    this.limit = clamp(t.coldStart, t.floor, t.ceil)
+    this.emit('regime-reset')
+    return this.limit
+  }
+
+  private applyHardDecrease(): number {
+    const t = this.tuning
+    this.limit = clamp(Math.round(this.limit * t.hardDecreaseFactor), t.floor, t.ceil)
+    this.enterHold(0)
+    this.prevGoodput = null
+    this.prevRatio = null
+    this.blindDoubleArmed = false
+    this.lastHardDownWindow = this.windowIndex
+    this.emit('hard-down')
+    // A hard decrease resets the window so we don't immediately move again.
+    this.resetWindow(this.windowStartedAt)
+    return this.limit
+  }
+
+  private tick(now: number): number | null {
+    const t = this.tuning
+    this.windowIndex++
+    const before = this.limit
+    const elapsedSec = Math.max((now - this.windowStartedAt) / 1000, 1e-6)
+    const goodput = this.completionsSinceTick / elapsedSec
+    const ratio = this.revalidatedSinceTick / this.completionsSinceTick
+
+    let reason: ControlTickReason
+    if (this.retriesSinceTick > 0) {
+      // Errors in the window: AIMD soft-decrease, then re-establish a baseline
+      // before climbing again (gated slow-start, like TCP after a loss).
+      this.limit = clamp(Math.round(this.limit * t.softDecreaseFactor), t.floor, t.ceil)
+      this.phase = 'slow-start'
+      this.blindDoubleArmed = false
+      this.probePending = false
+      this.prevGoodput = null
+      this.prevRatio = null
+      reason = 'soft-down'
+    } else if (
+      this.prevRatio !== null &&
+      Math.abs(ratio - this.prevRatio) > t.revalidatedComparableDelta
+    ) {
+      // Cache-mix shift: windows not comparable. Decide nothing, but roll the
+      // baseline so the next same-mix window is comparable again.
+      if (this.probePending) {
+        this.probePending = false
+        this.limit = this.preProbeLimit
+        reason = 'probe-reject'
+      } else {
+        reason = 'hold'
+      }
+      this.prevGoodput = goodput
+      this.prevRatio = ratio
+    } else {
+      reason = this.decide(goodput)
+      this.prevGoodput = goodput
+      this.prevRatio = ratio
+    }
+
+    this.emit(reason, now, goodput, ratio)
+    this.resetWindow(now)
+    return this.limit === before ? null : this.limit
+  }
+
+  private decide(goodput: number): ControlTickReason {
+    switch (this.phase) {
+      case 'slow-start':
+        return this.decideSlowStart(goodput)
+      case 'climb-up':
+        return this.decideClimbUp(goodput)
+      case 'climb-down':
+        return this.decideClimbDown(goodput)
+      default:
+        return this.decideHold(goodput)
+    }
+  }
+
+  private decideSlowStart(goodput: number): ControlTickReason {
+    const t = this.tuning
+    if (this.prevGoodput === null) {
+      if (this.blindDoubleArmed) {
+        // Cold start, no baseline yet: double optimistically — a wrong guess
+        // costs one window and the next gate reverts it.
+        this.blindDoubleArmed = false
+        return this.increase(this.limit * 2, 'double', goodput)
+      }
+      return 'hold' // baseline established, comparisons start next window
+    }
+    const gain = goodput / this.prevGoodput
+    if (gain >= t.strongGainFactor) {
+      return this.increase(this.limit * 2, 'double', goodput)
+    }
+    if (gain >= t.gainEpsilon) {
+      this.phase = 'climb-up'
+      return this.increase(this.limit + 1, 'up', goodput)
+    }
+    // Plateau. If we just moved up, that move bought nothing — revert it and
+    // probe below; otherwise (steady limit from a profile) count straight down.
+    this.phase = 'climb-down'
+    if (this.limitBeforeIncrease !== null && this.limitBeforeIncrease < this.limit) {
+      this.limit = this.limitBeforeIncrease
+      this.limitBeforeIncrease = null
+      return 'revert'
+    }
+    this.limit = clamp(this.limit - 1, t.floor, t.ceil)
+    return 'step-down'
+  }
+
+  private decideClimbUp(goodput: number): ControlTickReason {
+    const t = this.tuning
+    const gain = goodput / (this.prevGoodput ?? goodput)
+    if (gain >= t.gainEpsilon) {
+      return this.increase(this.limit + 1, 'up', goodput)
+    }
+    // The last +1 bought nothing: take it back and hold at the knee.
+    const knee = this.prevGoodput ?? goodput
+    this.limit = clamp(this.limit - 1, t.floor, t.ceil)
+    this.enterHold(knee)
+    return 'revert'
+  }
+
+  private decideClimbDown(goodput: number): ControlTickReason {
+    const t = this.tuning
+    const gain = goodput / (this.prevGoodput ?? goodput)
+    if (gain >= t.keepDownEpsilon) {
+      // Flat: fewer sockets, same throughput — keep descending.
+      if (this.limit <= t.floor) {
+        this.enterHold(goodput)
+        return 'hold'
+      }
+      this.limit -= 1
+      return 'step-down'
+    }
+    // Real loss: one step back up is the knee.
+    const knee = this.prevGoodput ?? goodput
+    this.limit = clamp(this.limit + 1, t.floor, t.ceil)
+    this.enterHold(knee)
+    return 'revert'
+  }
+
+  private decideHold(goodput: number): ControlTickReason {
+    const t = this.tuning
+    if (this.probePending) {
+      this.probePending = false
+      const gain = goodput / this.probeBaseline
+      if (gain >= t.gainEpsilon) {
+        // The probe bought real throughput — keep climbing.
+        this.phase = 'climb-up'
+        return this.increase(this.limit + 1, 'up', goodput)
+      }
+      this.limit = this.preProbeLimit
+      this.windowsSinceProbe = 0
+      return 'probe-reject'
+    }
+
+    this.bestGoodput = Math.max(this.bestGoodput * t.bestGoodputDecay, goodput)
+    if (goodput < t.holdDegradeFactor * this.bestGoodput) {
+      this.badStreak++
+      if (this.badStreak >= t.holdDegradeWindows) {
+        this.badStreak = 0
+        this.bestGoodput = goodput
+        if (this.limit > t.floor) {
+          this.limit -= 1
+          return 'step-down'
+        }
+      }
+      return 'hold'
+    }
+
+    this.badStreak = 0
+    this.windowsSinceProbe++
+    if (this.windowsSinceProbe >= t.reprobeAfterWindows && this.limit < t.ceil) {
+      this.probePending = true
+      this.preProbeLimit = this.limit
+      this.probeBaseline = goodput
+      this.windowsSinceProbe = 0
+      this.limit = clamp(this.limit + 1, t.floor, t.ceil)
+      return 'probe-up'
+    }
+    return 'hold'
+  }
+
+  private increase(target: number, reason: ControlTickReason, goodput: number): ControlTickReason {
+    const t = this.tuning
+    this.limitBeforeIncrease = this.limit
+    this.limit = clamp(target, t.floor, t.ceil)
+    if (this.limit === t.ceil) {
+      this.enterHold(goodput)
+    }
+    return reason
+  }
+
+  private enterHold(referenceGoodput: number): void {
+    this.phase = 'hold'
+    this.reachedHold = true
+    this.bestGoodput = referenceGoodput
+    this.badStreak = 0
+    this.windowsSinceProbe = 0
+    this.probePending = false
+    this.limitBeforeIncrease = null
+  }
+
+  private emit(
+    reason: ControlTickReason,
+    now: number = Date.now(),
+    goodput?: number,
+    ratio?: number
+  ): void {
+    this.onTick?.({
+      atMs: now,
+      limit: this.limit,
+      ewmaMs: Math.round(this.ewmaMs),
+      retries: this.retriesSinceTick,
+      reason,
+      state: this.phase,
+      ...(goodput !== undefined && ratio !== undefined
+        ? { goodputRps: round2(goodput), revalidatedRatio: Math.round(ratio * 1000) / 1000 }
+        : {}),
+    })
+  }
+
+  private resetWindow(now: number): void {
+    this.completionsSinceTick = 0
+    this.retriesSinceTick = 0
+    this.revalidatedSinceTick = 0
+    this.windowStartedAt = now
+  }
+}

--- a/src/shared/http/hill-climb-controller.ts
+++ b/src/shared/http/hill-climb-controller.ts
@@ -35,6 +35,7 @@
  */
 
 import { POOL_CONNECTIONS } from '../config/constants'
+import { clamp, Ewma, round2, roundTo } from '../math'
 import type { NetworkProfile } from '../types/domain'
 import type {
   ConcurrencyController,
@@ -43,7 +44,7 @@ import type {
   ControlTickReason,
   RequestOutcomeKind,
   RequestOutcomeMeta,
-} from './adaptive-controller'
+} from './controller-contract'
 
 export interface HillClimbTuning {
   /** Lower bound on the limit. */
@@ -121,9 +122,28 @@ const MIN_CONTROLLED_TOTAL = 30
  * poison the next run's regime check in either direction. */
 const MIN_BASELINE_SAMPLES = 4
 
-const clamp = (value: number, lo: number, hi: number): number => Math.max(lo, Math.min(hi, value))
-
-const round2 = (value: number): number => Math.round(value * 100) / 100
+/** Experiment/test overrides must still yield a working state machine: every
+ * knob is a positive finite number, and the count-like knobs are integers with
+ * sane lower bounds (a fractional window size or ceil < floor would wedge the
+ * controller in ways no test of the defaults ever exercises). */
+const sanitizeTuning = (t: HillClimbTuning): HillClimbTuning => {
+  for (const [key, value] of Object.entries(t)) {
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new Error(`HillClimbTuning.${key} must be a positive finite number, got ${value}`)
+    }
+  }
+  const floor = Math.max(1, Math.floor(t.floor))
+  return {
+    ...t,
+    floor,
+    ceil: Math.max(floor, Math.floor(t.ceil)),
+    coldStart: Math.max(1, Math.floor(t.coldStart)),
+    windowCompletions: Math.max(1, Math.floor(t.windowCompletions)),
+    holdDegradeWindows: Math.max(1, Math.floor(t.holdDegradeWindows)),
+    reprobeAfterWindows: Math.max(1, Math.floor(t.reprobeAfterWindows)),
+    validateAfterCompletions: Math.max(1, Math.floor(t.validateAfterCompletions)),
+  }
+}
 
 export interface HillClimbOptions {
   /** Persisted starting hypothesis; validated against live latency, never a cap. */
@@ -145,14 +165,11 @@ export class HillClimbController implements ConcurrencyController {
   private frozen = false
 
   // Latency EWMA over ALL successes: instrumentation only (perf modal / logs).
-  private ewmaMs = 0
-  private hasEwma = false
+  private readonly latencyEwma: Ewma
   // Latency EWMA over FULL fetches only (no 304s): feeds the regime check and
   // the persisted baseline. A 304 is fast on any link, so mixing it in would
   // let a cache-mix shift impersonate a network change.
-  private fullEwmaMs = 0
-  private hasFullEwma = false
-  private fullSamples = 0
+  private readonly fullLatencyEwma: Ewma
   private readonly profileBaselineMs: number | null = null
   private validationRemaining = 0
   private validatingWindows = 0
@@ -187,9 +204,11 @@ export class HillClimbController implements ConcurrencyController {
   private reachedHold = false
 
   constructor(packageCount: number, options: HillClimbOptions = {}) {
-    this.tuning = { ...HILL_CLIMB_TUNING, ...options.tuning }
+    this.tuning = sanitizeTuning({ ...HILL_CLIMB_TUNING, ...options.tuning })
     this.onTick = options.onTick
     const t = this.tuning
+    this.latencyEwma = new Ewma(t.ewmaAlpha)
+    this.fullLatencyEwma = new Ewma(t.ewmaAlpha)
     const profile = options.profile ?? null
     if (profile) {
       this.limit = clamp(Math.round(profile.learnedLimit), t.floor, t.ceil)
@@ -201,7 +220,9 @@ export class HillClimbController implements ConcurrencyController {
       this.phase = 'slow-start'
       this.blindDoubleArmed = true
     }
-    // Never more parallel than there is work.
+    // Never more parallel than there is work. This may land below `floor`
+    // for tiny runs; harmless today because shouldControl() gates runs < 30,
+    // but the floor invariant does NOT survive a caller that skips the gate.
     this.limit = Math.min(this.limit, Math.max(1, packageCount))
     this.windowStartedAt = options.startedAt ?? Date.now()
   }
@@ -238,9 +259,9 @@ export class HillClimbController implements ConcurrencyController {
       const revalidated = meta?.revalidated === true
       if (revalidated) this.revalidatedSinceTick++
       if (latencyMs !== undefined) {
-        this.sampleLatency(latencyMs)
+        this.latencyEwma.update(latencyMs)
         if (!revalidated) {
-          this.sampleFullLatency(latencyMs)
+          this.fullLatencyEwma.update(latencyMs)
           // Only full fetches inform the regime check: a warm-cache 304 looks
           // fast on the slowest of links.
           if (this.phase === 'validating') return this.validateProfile()
@@ -284,35 +305,14 @@ export class HillClimbController implements ConcurrencyController {
     // No trustworthy latency baseline (all-304 warm run): persist nothing —
     // better to keep last run's profile than to store one that cannot be
     // regime-checked next time.
-    if (this.fullSamples < MIN_BASELINE_SAMPLES) return null
+    if (this.fullLatencyEwma.count < MIN_BASELINE_SAMPLES) return null
     return {
       schemaVersion: 1,
       learnedLimit: this.limit,
-      baselineLatencyMs: Math.round(this.fullEwmaMs),
+      baselineLatencyMs: Math.round(this.fullLatencyEwma.value),
       baselineGoodputRps: round2(this.prevGoodput ?? 0),
       sampleCount: this.totalCompletions,
       updatedAt: new Date(now).toISOString(),
-    }
-  }
-
-  private sampleLatency(latencyMs: number): void {
-    if (!this.hasEwma) {
-      this.ewmaMs = latencyMs
-      this.hasEwma = true
-    } else {
-      const a = this.tuning.ewmaAlpha
-      this.ewmaMs = a * latencyMs + (1 - a) * this.ewmaMs
-    }
-  }
-
-  private sampleFullLatency(latencyMs: number): void {
-    this.fullSamples++
-    if (!this.hasFullEwma) {
-      this.fullEwmaMs = latencyMs
-      this.hasFullEwma = true
-    } else {
-      const a = this.tuning.ewmaAlpha
-      this.fullEwmaMs = a * latencyMs + (1 - a) * this.fullEwmaMs
     }
   }
 
@@ -336,10 +336,10 @@ export class HillClimbController implements ConcurrencyController {
     // Full-fetch latency on both sides of the comparison: the stored baseline
     // is full-fetch-only too (getSettledProfile), so a cache-mix difference
     // between the runs cannot impersonate a network change.
-    const worse = this.fullEwmaMs > Math.max(t.regimeWorseFactor * baseline, t.regimeWorseMinMs)
+    const fullMs = this.fullLatencyEwma.value
+    const worse = fullMs > Math.max(t.regimeWorseFactor * baseline, t.regimeWorseMinMs)
     const better =
-      baseline - this.fullEwmaMs > t.regimeBetterMinDeltaMs &&
-      this.fullEwmaMs * t.regimeWorseFactor < baseline
+      baseline - fullMs > t.regimeBetterMinDeltaMs && fullMs * t.regimeWorseFactor < baseline
     this.phase = 'slow-start'
     if (!worse && !better) {
       // Same regime: climb from the learned limit, gated from here on.
@@ -607,12 +607,12 @@ export class HillClimbController implements ConcurrencyController {
     this.onTick?.({
       atMs: now,
       limit: this.limit,
-      ewmaMs: Math.round(this.ewmaMs),
+      ewmaMs: Math.round(this.latencyEwma.value),
       retries: this.retriesSinceTick,
       reason,
       state: this.phase,
       ...(goodput !== undefined && ratio !== undefined
-        ? { goodputRps: round2(goodput), revalidatedRatio: Math.round(ratio * 1000) / 1000 }
+        ? { goodputRps: round2(goodput), revalidatedRatio: roundTo(ratio, 3) }
         : {}),
     })
   }

--- a/src/shared/http/hill-climb-controller.ts
+++ b/src/shared/http/hill-climb-controller.ts
@@ -291,7 +291,12 @@ export class HillClimbController implements ConcurrencyController {
     this.validationRemaining--
     if (this.validationRemaining > 0) return null
     const t = this.tuning
+    // The 'validating' phase only exists when a profile was supplied, and the
+    // constructor sets the baseline together with it; the fallback is for the
+    // field's nullable type only.
+    /* v8 ignore start */
     const baseline = this.profileBaselineMs ?? 0
+    /* v8 ignore stop */
     const worse = this.ewmaMs > Math.max(t.regimeWorseFactor * baseline, t.regimeWorseMinMs)
     const better =
       baseline - this.ewmaMs > t.regimeBetterMinDeltaMs &&
@@ -414,20 +419,28 @@ export class HillClimbController implements ConcurrencyController {
 
   private decideClimbUp(goodput: number): ControlTickReason {
     const t = this.tuning
-    const gain = goodput / (this.prevGoodput ?? goodput)
+    // Climb states are only entered from a decided (comparable) window, so a
+    // baseline always exists; the fallback only guards impossible-null math.
+    /* v8 ignore start */
+    const prev = this.prevGoodput ?? goodput
+    /* v8 ignore stop */
+    const gain = goodput / prev
     if (gain >= t.gainEpsilon) {
       return this.increase(this.limit + 1, 'up', goodput)
     }
     // The last +1 bought nothing: take it back and hold at the knee.
-    const knee = this.prevGoodput ?? goodput
     this.limit = clamp(this.limit - 1, t.floor, t.ceil)
-    this.enterHold(knee)
+    this.enterHold(prev)
     return 'revert'
   }
 
   private decideClimbDown(goodput: number): ControlTickReason {
     const t = this.tuning
-    const gain = goodput / (this.prevGoodput ?? goodput)
+    // Same invariant as decideClimbUp: the baseline is always present here.
+    /* v8 ignore start */
+    const prev = this.prevGoodput ?? goodput
+    /* v8 ignore stop */
+    const gain = goodput / prev
     if (gain >= t.keepDownEpsilon) {
       // Flat: fewer sockets, same throughput — keep descending.
       if (this.limit <= t.floor) {
@@ -438,9 +451,8 @@ export class HillClimbController implements ConcurrencyController {
       return 'step-down'
     }
     // Real loss: one step back up is the knee.
-    const knee = this.prevGoodput ?? goodput
     this.limit = clamp(this.limit + 1, t.floor, t.ceil)
-    this.enterHold(knee)
+    this.enterHold(prev)
     return 'revert'
   }
 

--- a/src/shared/http/hill-climb-controller.ts
+++ b/src/shared/http/hill-climb-controller.ts
@@ -116,6 +116,11 @@ export const HILL_CLIMB_TUNING: HillClimbTuning = {
 /** Runs below this size cannot close two windows plus a tail — skip control. */
 const MIN_CONTROLLED_TOTAL = 30
 
+/** Full (non-304) fetches needed before a latency baseline is worth persisting.
+ * A 304 is header-sized and fast on any link; a baseline diluted by 304s would
+ * poison the next run's regime check in either direction. */
+const MIN_BASELINE_SAMPLES = 4
+
 const clamp = (value: number, lo: number, hi: number): number => Math.max(lo, Math.min(hi, value))
 
 const round2 = (value: number): number => Math.round(value * 100) / 100
@@ -139,20 +144,30 @@ export class HillClimbController implements ConcurrencyController {
   private phase: ConcurrencyControllerState
   private frozen = false
 
-  // Latency EWMA: instrumentation plus the one-shot regime check — decisions
-  // never read it (see the class docblock).
+  // Latency EWMA over ALL successes: instrumentation only (perf modal / logs).
   private ewmaMs = 0
   private hasEwma = false
+  // Latency EWMA over FULL fetches only (no 304s): feeds the regime check and
+  // the persisted baseline. A 304 is fast on any link, so mixing it in would
+  // let a cache-mix shift impersonate a network change.
+  private fullEwmaMs = 0
+  private hasFullEwma = false
+  private fullSamples = 0
   private readonly profileBaselineMs: number | null = null
   private validationRemaining = 0
+  private validatingWindows = 0
 
   private completionsSinceTick = 0
   private retriesSinceTick = 0
   private revalidatedSinceTick = 0
+  /** Successful completions (attempts that failed do not count as evidence). */
   private totalCompletions = 0
   private windowStartedAt: number
   private windowIndex = 0
   private lastHardDownWindow = Number.NEGATIVE_INFINITY
+  /** A hard-down reset the counters mid-window but record() has no clock to
+   * reset the window start — the next tick must discard that half-timed window. */
+  private windowClockDirty = false
 
   /** Goodput and 304-share of the last closed comparable-or-rolled window. */
   private prevGoodput: number | null = null
@@ -217,13 +232,19 @@ export class HillClimbController implements ConcurrencyController {
    */
   record(kind: RequestOutcomeKind, latencyMs?: number, meta?: RequestOutcomeMeta): number | null {
     this.completionsSinceTick++
-    this.totalCompletions++
 
     if (kind === 'success') {
-      if (meta?.revalidated) this.revalidatedSinceTick++
+      this.totalCompletions++
+      const revalidated = meta?.revalidated === true
+      if (revalidated) this.revalidatedSinceTick++
       if (latencyMs !== undefined) {
         this.sampleLatency(latencyMs)
-        if (this.phase === 'validating') return this.validateProfile()
+        if (!revalidated) {
+          this.sampleFullLatency(latencyMs)
+          // Only full fetches inform the regime check: a warm-cache 304 looks
+          // fast on the slowest of links.
+          if (this.phase === 'validating') return this.validateProfile()
+        }
       }
       return null
     }
@@ -260,10 +281,14 @@ export class HillClimbController implements ConcurrencyController {
     if (!this.reachedHold) return null
     if (this.totalCompletions < MIN_CONTROLLED_TOTAL) return null
     if (this.windowIndex - this.lastHardDownWindow < 2) return null
+    // No trustworthy latency baseline (all-304 warm run): persist nothing —
+    // better to keep last run's profile than to store one that cannot be
+    // regime-checked next time.
+    if (this.fullSamples < MIN_BASELINE_SAMPLES) return null
     return {
       schemaVersion: 1,
       learnedLimit: this.limit,
-      baselineLatencyMs: Math.round(this.ewmaMs),
+      baselineLatencyMs: Math.round(this.fullEwmaMs),
       baselineGoodputRps: round2(this.prevGoodput ?? 0),
       sampleCount: this.totalCompletions,
       updatedAt: new Date(now).toISOString(),
@@ -277,6 +302,17 @@ export class HillClimbController implements ConcurrencyController {
     } else {
       const a = this.tuning.ewmaAlpha
       this.ewmaMs = a * latencyMs + (1 - a) * this.ewmaMs
+    }
+  }
+
+  private sampleFullLatency(latencyMs: number): void {
+    this.fullSamples++
+    if (!this.hasFullEwma) {
+      this.fullEwmaMs = latencyMs
+      this.hasFullEwma = true
+    } else {
+      const a = this.tuning.ewmaAlpha
+      this.fullEwmaMs = a * latencyMs + (1 - a) * this.fullEwmaMs
     }
   }
 
@@ -297,10 +333,13 @@ export class HillClimbController implements ConcurrencyController {
     /* v8 ignore start */
     const baseline = this.profileBaselineMs ?? 0
     /* v8 ignore stop */
-    const worse = this.ewmaMs > Math.max(t.regimeWorseFactor * baseline, t.regimeWorseMinMs)
+    // Full-fetch latency on both sides of the comparison: the stored baseline
+    // is full-fetch-only too (getSettledProfile), so a cache-mix difference
+    // between the runs cannot impersonate a network change.
+    const worse = this.fullEwmaMs > Math.max(t.regimeWorseFactor * baseline, t.regimeWorseMinMs)
     const better =
-      baseline - this.ewmaMs > t.regimeBetterMinDeltaMs &&
-      this.ewmaMs * t.regimeWorseFactor < baseline
+      baseline - this.fullEwmaMs > t.regimeBetterMinDeltaMs &&
+      this.fullEwmaMs * t.regimeWorseFactor < baseline
     this.phase = 'slow-start'
     if (!worse && !better) {
       // Same regime: climb from the learned limit, gated from here on.
@@ -323,30 +362,71 @@ export class HillClimbController implements ConcurrencyController {
     this.blindDoubleArmed = false
     this.lastHardDownWindow = this.windowIndex
     this.emit('hard-down')
-    // A hard decrease resets the window so we don't immediately move again.
+    // Reset the window counters so we don't immediately move again. record()
+    // has no clock to restart the window timer, so the current window's
+    // elapsed time is wrong — mark it and let the next tick discard it.
     this.resetWindow(this.windowStartedAt)
+    this.windowClockDirty = true
     return this.limit
   }
 
   private tick(now: number): number | null {
     const t = this.tuning
-    this.windowIndex++
     const before = this.limit
-    const elapsedSec = Math.max((now - this.windowStartedAt) / 1000, 1e-6)
-    const goodput = this.completionsSinceTick / elapsedSec
-    const ratio = this.revalidatedSinceTick / this.completionsSinceTick
+    const measurable = now > this.windowStartedAt && !this.windowClockDirty
+    this.windowClockDirty = false
 
-    let reason: ControlTickReason
+    // Errors in the window: AIMD soft-decrease, then re-establish a baseline
+    // before climbing again (gated slow-start, like TCP after a loss). The
+    // signal is the errors themselves — no goodput needed, so this branch
+    // runs even for a window whose elapsed time is unmeasurable.
+    // Validation is NOT abandoned: flaky links are exactly where the regime
+    // check matters, and errors say nothing about the latency comparison.
     if (this.retriesSinceTick > 0) {
-      // Errors in the window: AIMD soft-decrease, then re-establish a baseline
-      // before climbing again (gated slow-start, like TCP after a loss).
+      this.windowIndex++
       this.limit = clamp(Math.round(this.limit * t.softDecreaseFactor), t.floor, t.ceil)
-      this.phase = 'slow-start'
+      if (this.phase !== 'validating') this.phase = 'slow-start'
       this.blindDoubleArmed = false
       this.probePending = false
       this.prevGoodput = null
       this.prevRatio = null
-      reason = 'soft-down'
+      // The pre-error revert point is stale now — a later plateau must step
+      // ±1 from the post-soft-down limit, never snap back across it.
+      this.limitBeforeIncrease = null
+      // No goodput fields on this tick: the window's timing may be invalid,
+      // and the soft-down decision never reads it anyway.
+      this.emit('soft-down', now)
+      this.resetWindow(now)
+      return this.limit === before ? null : this.limit
+    }
+
+    // Unmeasurable clean window: the clock did not move forward (zero or
+    // backward step — Date.now() is not monotonic) or the window straddles a
+    // hard-down whose timer could not be restarted. No goodput can be derived;
+    // decide nothing and let the next full window re-establish the baseline.
+    if (!measurable) {
+      this.resetWindow(now)
+      return null
+    }
+
+    this.windowIndex++
+    const elapsedSec = (now - this.windowStartedAt) / 1000
+    const goodput = this.completionsSinceTick / elapsedSec
+    const ratio = this.revalidatedSinceTick / this.completionsSinceTick
+
+    let reason: ControlTickReason
+    if (this.phase === 'validating') {
+      // A clean window closed but the latency check is still short of full
+      // fetches — a warm cache serves mostly 304s. One more window of grace,
+      // then trust the learned limit: a warm run is cheap at any limit and
+      // the goodput gates take over from here.
+      this.validatingWindows++
+      if (this.validatingWindows >= 2) {
+        this.phase = 'slow-start'
+      }
+      this.prevGoodput = goodput
+      this.prevRatio = ratio
+      reason = 'hold'
     } else if (
       this.prevRatio !== null &&
       Math.abs(ratio - this.prevRatio) > t.revalidatedComparableDelta

--- a/src/shared/math.ts
+++ b/src/shared/math.ts
@@ -1,0 +1,32 @@
+/** Numeric primitives shared by the concurrency controllers and the TUI. */
+
+export const clamp = (value: number, lo: number, hi: number): number =>
+  Math.max(lo, Math.min(hi, value))
+
+export const roundTo = (value: number, digits: number): number => {
+  const factor = 10 ** digits
+  return Math.round(value * factor) / factor
+}
+
+export const round2 = (value: number): number => roundTo(value, 2)
+
+/** Exponentially weighted moving average, seeded by the first sample. */
+export class Ewma {
+  private ewma = 0
+  private samples = 0
+
+  constructor(private readonly alpha: number) {}
+
+  update(sample: number): void {
+    this.ewma = this.samples === 0 ? sample : this.alpha * sample + (1 - this.alpha) * this.ewma
+    this.samples++
+  }
+
+  get value(): number {
+    return this.ewma
+  }
+
+  get count(): number {
+    return this.samples
+  }
+}

--- a/src/shared/registry/npm-registry.ts
+++ b/src/shared/registry/npm-registry.ts
@@ -7,8 +7,13 @@ const inflateAsync = promisify(inflate)
 const brotliDecompressAsync = promisify(brotliDecompress)
 
 import { POOL_CONNECTIONS } from '../config'
-import { AdaptiveController, type ControlTick } from '../http/adaptive-controller'
+import {
+  AdaptiveController,
+  type ConcurrencyController,
+  type ControlTick,
+} from '../http/adaptive-controller'
 import { readEtag, writeEtag } from '../http/etag-store'
+import { HillClimbController } from '../http/hill-climb-controller'
 import { InflightMap } from '../http/inflight'
 import { ResizableSemaphore } from '../http/resizable-semaphore'
 import {
@@ -96,7 +101,7 @@ const encodeRegistryPath = (packageName: string, pathPrefix: string): string => 
 }
 
 type RegistryAttemptOutcome =
-  | { kind: 'success'; data: PackageVersionData; latencyMs: number }
+  | { kind: 'success'; data: PackageVersionData; latencyMs: number; revalidated: boolean }
   | { kind: 'not-found' }
   | { kind: 'retryable' }
   | { kind: 'congested'; retryAfterMs: number | null }
@@ -145,7 +150,12 @@ async function attemptRegistryFetch(
     // Registry confirmed our cached copy is current — reuse it, skip the download.
     if (statusCode === 304 && cached) {
       await body.dump().catch(() => undefined)
-      return { kind: 'success', data: cached.data, latencyMs: Date.now() - startedAt }
+      return {
+        kind: 'success',
+        data: cached.data,
+        latencyMs: Date.now() - startedAt,
+        revalidated: true,
+      }
     }
 
     if (statusCode < 200 || statusCode >= 300) {
@@ -190,6 +200,7 @@ async function attemptRegistryFetch(
       kind: 'success',
       data,
       latencyMs: Date.now() - startedAt,
+      revalidated: false,
     }
   } catch (error) {
     if (isTransientNetworkError(error)) {
@@ -253,12 +264,16 @@ async function fetchPackageFromRegistry(
  * - A single resizable semaphore caps in-flight fetches. Package names are
  *   pulled from a work queue and dispatched as slots free up (a lazy pump),
  *   rather than pre-sliced into fixed batches.
- * - `adaptive` (default true) enables an AIMD controller that ramps the limit to
- *   the ceiling on a healthy link and backs off on congestion (429/503) or
- *   errors. With `adaptive:false` the limit is fixed at `maxConcurrency` (the A/B
- *   control arm), reproducing the legacy fixed path.
- * - Tiny runs (<= ceil packages) skip the controller and run at a fixed
- *   `min(ceil, count)` so they never crawl up from the floor and lose to fixed.
+ * - `adaptive` (default true) enables a controller that moves the limit at run
+ *   time. `controllerMode` picks which: 'hillclimb' (default) slow-starts and
+ *   climbs to the goodput knee — adapting DOWN on slow-but-healthy links;
+ *   'aimd' (the A/B control arm) ramps to the ceiling and backs off only on
+ *   congestion (429/503) or errors. With `adaptive:false` the limit is fixed at
+ *   `maxConcurrency`, reproducing the legacy fixed path. `concurrency` pins the
+ *   limit outright and disables everything adaptive.
+ * - Tiny runs skip the controller and run at a fixed `min(learned ?? ceil, count)`
+ *   so they never crawl up from the floor and lose to fixed — while still
+ *   honoring a persisted slow-link profile.
  * - No body timeout: slow responses finish. Real network errors and header
  *   stalls are retried with backoff; after the retry budget is exhausted the
  *   package is reported unavailable (`latestVersion: 'unknown'`).
@@ -270,6 +285,8 @@ async function fetchPackageFromRegistry(
  *   gate concurrency.
  * - `onControlTick` (optional) reports each adaptive control decision for
  *   instrumentation.
+ * - `onNetworkProfile` (optional) fires once at the end of a run whose
+ *   hill-climb controller settled on a limit worth persisting.
  */
 export async function fetchPackageVersions(
   packageNames: string[],
@@ -288,21 +305,35 @@ export async function fetchPackageVersions(
     return packageData
   }
 
-  const adaptive = options.adaptive ?? true
+  const pinned = options.concurrency
+  const adaptive = pinned === undefined && (options.adaptive ?? true)
+  const controllerMode = options.controllerMode ?? 'hillclimb'
+  const networkProfile = options.networkProfile ?? null
   // `maxConcurrency` is the fixed cap used only when adaptive is off; it never
-  // caps the adaptive start (the controller smart-starts near the work size and
-  // ramps to the ceiling, which beats a low fixed start on large runs).
+  // caps the adaptive start.
   const fixedConcurrency = Math.max(1, options.maxConcurrency ?? DEFAULT_FIXED_CONCURRENCY)
 
-  const controller =
-    adaptive && AdaptiveController.shouldControl(total)
-      ? new AdaptiveController(total, options.onControlTick)
-      : null
-  const initialLimit = controller
-    ? controller.getLimit()
-    : adaptive
-      ? Math.min(POOL_CONNECTIONS, total) // too small to control: smart fixed start
-      : fixedConcurrency
+  let controller: ConcurrencyController | null = null
+  if (adaptive) {
+    if (controllerMode === 'hillclimb' && HillClimbController.shouldControl(total)) {
+      controller = new HillClimbController(total, {
+        profile: networkProfile,
+        onTick: options.onControlTick,
+      })
+    } else if (controllerMode === 'aimd' && AdaptiveController.shouldControl(total)) {
+      controller = new AdaptiveController(total, options.onControlTick)
+    }
+  }
+  const initialLimit =
+    pinned !== undefined
+      ? Math.max(1, Math.min(Math.floor(pinned), total))
+      : controller
+        ? controller.getLimit()
+        : adaptive
+          ? // Too small to control: smart fixed start, capped by any learned
+            // slow-link limit so small projects still benefit from the profile.
+            Math.max(1, Math.min(networkProfile?.learnedLimit ?? POOL_CONNECTIONS, total))
+          : fixedConcurrency
   const semaphore = new ResizableSemaphore(initialLimit)
 
   // --- emission ordering (unchanged contract) ---------------------------------
@@ -355,7 +386,12 @@ export async function fetchPackageVersions(
     if (!controller && !options.onPackageTiming) return undefined
     return (outcome) => {
       if (outcome.kind === 'success') {
-        controller?.record('success', outcome.latencyMs)
+        // A success can also demand an immediate limit change (the hill-climb
+        // controller's failed profile validation), so apply any returned limit.
+        const next = controller?.record('success', outcome.latencyMs, {
+          revalidated: outcome.revalidated,
+        })
+        if (next != null) semaphore.setLimit(next)
         options.onPackageTiming?.(packageName, outcome.latencyMs)
       } else if (outcome.kind === 'congested') {
         const next = controller?.record('congested')
@@ -400,6 +436,11 @@ export async function fetchPackageVersions(
       }
 
       if (controller) {
+        // Run tail: with fewer pending items than the limit the drain would
+        // read as a goodput collapse — stop deciding (and stop learning).
+        if (total - completedCount < 2 * controller.getLimit()) {
+          controller.freeze?.()
+        }
         const next = controller.maybeTick()
         if (next !== null) semaphore.setLimit(next)
       }
@@ -419,6 +460,12 @@ export async function fetchPackageVersions(
   }
 
   await Promise.all(workers)
+
+  if (controller instanceof HillClimbController && options.onNetworkProfile) {
+    const settled = controller.getSettledProfile()
+    if (settled) options.onNetworkProfile(settled)
+  }
+
   return packageData
 }
 

--- a/src/shared/registry/npm-registry.ts
+++ b/src/shared/registry/npm-registry.ts
@@ -7,11 +7,8 @@ const inflateAsync = promisify(inflate)
 const brotliDecompressAsync = promisify(brotliDecompress)
 
 import { POOL_CONNECTIONS } from '../config'
-import {
-  AdaptiveController,
-  type ConcurrencyController,
-  type ControlTick,
-} from '../http/adaptive-controller'
+import { AdaptiveController } from '../http/adaptive-controller'
+import type { ConcurrencyController, ControlTick } from '../http/controller-contract'
 import { readEtag, writeEtag } from '../http/etag-store'
 import { HillClimbController } from '../http/hill-climb-controller'
 import { InflightMap } from '../http/inflight'
@@ -23,6 +20,7 @@ import {
   parseRetryAfterMs,
   sleep,
 } from '../http/retry'
+import { clamp } from '../math'
 import type {
   FetchPackageVersionsOptions,
   OnBatchReadyCallback,
@@ -326,7 +324,9 @@ export async function fetchPackageVersions(
   }
   const initialLimit =
     pinned !== undefined
-      ? Math.max(1, Math.min(Math.floor(pinned), total))
+      ? // Belt-and-braces: cli/.inuprc validators already bound the pin, but
+        // this is the last stop before the semaphore — never exceed the pool.
+        clamp(Math.floor(pinned), 1, Math.min(total, POOL_CONNECTIONS))
       : controller
         ? controller.getLimit()
         : adaptive

--- a/src/shared/types/domain.ts
+++ b/src/shared/types/domain.ts
@@ -105,7 +105,8 @@ export interface UpgradeOptions extends VulnerabilityDisplayOptions {
   ignorePackages?: string[] // Package names/patterns to ignore (from .inuprc or --ignore flag)
   debug?: boolean // Write verbose debug log to /tmp/inup-debug-YYYY-MM-DD.log
   saveExact?: boolean // Write bare versions instead of preserving the range prefix (^/~)
-  adaptive?: boolean // Adaptive registry concurrency (AIMD). Defaults to true.
+  adaptive?: boolean // Adaptive registry concurrency. Defaults to true.
+  concurrency?: number // Pin registry fetch parallelism (1..24) and disable adaptation
 }
 
 /**

--- a/src/shared/types/domain.ts
+++ b/src/shared/types/domain.ts
@@ -108,6 +108,26 @@ export interface UpgradeOptions extends VulnerabilityDisplayOptions {
   adaptive?: boolean // Adaptive registry concurrency (AIMD). Defaults to true.
 }
 
+/**
+ * Locally persisted network shape learned by the hill-climb concurrency
+ * controller. A starting hypothesis for the next run — never a hard cap: the
+ * controller re-validates it against live latency at run start and discards it
+ * when the network regime changed (different location, VPN, tethering).
+ */
+export interface NetworkProfile {
+  schemaVersion: 1
+  /** Last stable HOLD limit the controller settled at. */
+  learnedLimit: number
+  /** Success-only single-attempt latency EWMA at the end of that run. */
+  baselineLatencyMs: number
+  /** Window goodput (completions/sec) at settle time; diagnostic only. */
+  baselineGoodputRps: number
+  /** Completions that informed the profile. */
+  sampleCount: number
+  /** ISO timestamp; profiles expire after a few days. */
+  updatedAt: string
+}
+
 export interface PackageJson {
   dependencies?: Record<string, string>
   devDependencies?: Record<string, string>

--- a/src/shared/types/streaming.ts
+++ b/src/shared/types/streaming.ts
@@ -1,4 +1,4 @@
-import type { DependencyEntry, PackageInfo } from './domain'
+import type { DependencyEntry, NetworkProfile, PackageInfo } from './domain'
 
 export interface PackageLoadProgress {
   discovered: number
@@ -53,10 +53,32 @@ export interface FetchPackageVersionsOptions {
   /** Sequence of batch sizes; overrides batchSize when provided. */
   batchSizes?: number[]
   /**
-   * Enable the AIMD adaptive-concurrency controller. Default: true. Set false to
+   * Enable the adaptive-concurrency controller. Default: true. Set false to
    * pin concurrency at `maxConcurrency` (legacy fixed behavior / A/B baseline).
    */
   adaptive?: boolean
+  /**
+   * Pin registry-fetch concurrency to exactly this value and disable all
+   * adaptation (and profile learning). The user-facing escape hatch.
+   */
+  concurrency?: number
+  /**
+   * Which adaptive controller drives the limit. Default: 'hillclimb'
+   * (slow-start + goodput hill-climb, adapts down on slow links);
+   * 'aimd' is the previous behavior, kept as the A/B control arm.
+   */
+  controllerMode?: 'aimd' | 'hillclimb'
+  /**
+   * Persisted starting hypothesis for the hill-climb controller. Validated
+   * against live latency at run start — never a hard cap. Also caps the fixed
+   * start of runs too small to control.
+   */
+  networkProfile?: NetworkProfile | null
+  /**
+   * Fires once at end of run with the settled profile worth persisting
+   * (hill-climb controller only; pinned and fixed runs never learn).
+   */
+  onNetworkProfile?: (profile: NetworkProfile) => void
 }
 
 export interface RegistryBatchProgressItem {

--- a/src/shared/types/streaming.ts
+++ b/src/shared/types/streaming.ts
@@ -6,6 +6,9 @@ export interface PackageLoadProgress {
   total: number
   failed: number
   isLoading: boolean
+  /** The concurrency controller settled low / latency is high: tell the user
+   * the wait is the connection, not a hang. */
+  slowNetwork?: boolean
 }
 
 export interface AuditProgress {

--- a/test/integration/services.test.ts
+++ b/test/integration/services.test.ts
@@ -18,72 +18,92 @@ describe('Services Integration Tests', () => {
       fetcher.clearCache()
     })
 
-    it(`should fetch metadata for ${PACKAGE_NAME}`, async () => {
-      const packageVersion =
-        (await fetchPackageVersions([PACKAGE_NAME])).get(PACKAGE_NAME)?.latestVersion ?? ''
+    it(
+      `should fetch metadata for ${PACKAGE_NAME}`,
+      async () => {
+        const packageVersion =
+          (await fetchPackageVersions([PACKAGE_NAME])).get(PACKAGE_NAME)?.latestVersion ?? ''
 
-      expect(packageVersion).toMatch(/^\d+\.\d+\.\d+$/)
-      const metadata = await fetcher.fetchPackageMetadata(PACKAGE_NAME, packageVersion)
+        expect(packageVersion).toMatch(/^\d+\.\d+\.\d+$/)
+        const metadata = await fetcher.fetchPackageMetadata(PACKAGE_NAME, packageVersion)
 
-      expect(metadata).not.toBeNull()
-      expect(metadata?.description).toBeTruthy()
-      expect(metadata?.repositoryUrl).toBeTruthy()
-      expect(metadata?.repositoryUrl).toContain('github.com')
-      expect(metadata?.npmUrl).toBe('https://www.npmjs.com/package/inup')
-      expect(metadata?.license).toBeTruthy()
-    }, LIVE_NETWORK_TIMEOUT_MS)
+        expect(metadata).not.toBeNull()
+        expect(metadata?.description).toBeTruthy()
+        expect(metadata?.repositoryUrl).toBeTruthy()
+        expect(metadata?.repositoryUrl).toContain('github.com')
+        expect(metadata?.npmUrl).toBe('https://www.npmjs.com/package/inup')
+        expect(metadata?.license).toBeTruthy()
+      },
+      LIVE_NETWORK_TIMEOUT_MS
+    )
 
-    it('should return null for nonexistent package', async () => {
-      const metadata = await fetcher.fetchPackageMetadata(
-        'this-package-definitely-does-not-exist-xyz123'
-      )
+    it(
+      'should return null for nonexistent package',
+      async () => {
+        const metadata = await fetcher.fetchPackageMetadata(
+          'this-package-definitely-does-not-exist-xyz123'
+        )
 
-      expect(metadata).toBeNull()
-    }, LIVE_NETWORK_TIMEOUT_MS)
+        expect(metadata).toBeNull()
+      },
+      LIVE_NETWORK_TIMEOUT_MS
+    )
 
-    it('should use cache on second fetch', async () => {
-      const packageVersion =
-        (await fetchPackageVersions([PACKAGE_NAME])).get(PACKAGE_NAME)?.latestVersion ?? ''
+    it(
+      'should use cache on second fetch',
+      async () => {
+        const packageVersion =
+          (await fetchPackageVersions([PACKAGE_NAME])).get(PACKAGE_NAME)?.latestVersion ?? ''
 
-      const start1 = Date.now()
-      await fetcher.fetchPackageMetadata('inup', packageVersion)
-      const duration1 = Date.now() - start1
+        const start1 = Date.now()
+        await fetcher.fetchPackageMetadata('inup', packageVersion)
+        const duration1 = Date.now() - start1
 
-      const start2 = Date.now()
-      await fetcher.fetchPackageMetadata('inup', packageVersion)
-      const duration2 = Date.now() - start2
+        const start2 = Date.now()
+        await fetcher.fetchPackageMetadata('inup', packageVersion)
+        const duration2 = Date.now() - start2
 
-      // Second fetch should be significantly faster (cached)
-      expect(duration2).toBeLessThan(duration1 / 2)
-    }, LIVE_NETWORK_TIMEOUT_MS)
+        // Second fetch should be significantly faster (cached)
+        expect(duration2).toBeLessThan(duration1 / 2)
+      },
+      LIVE_NETWORK_TIMEOUT_MS
+    )
   })
 
   describe(`npm-registry with ${PACKAGE_NAME}`, () => {
-    it(`should fetch version data for ${PACKAGE_NAME}`, async () => {
-      const result = await fetchPackageVersions([PACKAGE_NAME])
+    it(
+      `should fetch version data for ${PACKAGE_NAME}`,
+      async () => {
+        const result = await fetchPackageVersions([PACKAGE_NAME])
 
-      expect(result.size).toBe(1)
-      const testData = result.get(PACKAGE_NAME)
-      expect(testData).toBeDefined()
-      expect(testData?.latestVersion).toMatch(/^\d+\.\d+\.\d+$/)
-      expect(testData?.allVersions.length).toBeGreaterThan(0)
-      expect(testData?.allVersions[0]).toBe(testData?.latestVersion)
-    }, LIVE_NETWORK_TIMEOUT_MS)
+        expect(result.size).toBe(1)
+        const testData = result.get(PACKAGE_NAME)
+        expect(testData).toBeDefined()
+        expect(testData?.latestVersion).toMatch(/^\d+\.\d+\.\d+$/)
+        expect(testData?.allVersions.length).toBeGreaterThan(0)
+        expect(testData?.allVersions[0]).toBe(testData?.latestVersion)
+      },
+      LIVE_NETWORK_TIMEOUT_MS
+    )
 
-    it('should filter out pre-release versions', async () => {
-      const result = await fetchPackageVersions([PACKAGE_NAME])
+    it(
+      'should filter out pre-release versions',
+      async () => {
+        const result = await fetchPackageVersions([PACKAGE_NAME])
 
-      const testData = result.get(PACKAGE_NAME)
-      expect(testData).toBeDefined()
+        const testData = result.get(PACKAGE_NAME)
+        expect(testData).toBeDefined()
 
-      // All versions should be stable (X.Y.Z format, no -beta, -rc, etc.)
-      testData?.allVersions.forEach((version: string) => {
-        expect(version).toMatch(/^\d+\.\d+\.\d+$/)
-        expect(version).not.toContain('-')
-        expect(version).not.toContain('alpha')
-        expect(version).not.toContain('beta')
-        expect(version).not.toContain('rc')
-      })
-    }, LIVE_NETWORK_TIMEOUT_MS)
+        // All versions should be stable (X.Y.Z format, no -beta, -rc, etc.)
+        testData?.allVersions.forEach((version: string) => {
+          expect(version).toMatch(/^\d+\.\d+\.\d+$/)
+          expect(version).not.toContain('-')
+          expect(version).not.toContain('alpha')
+          expect(version).not.toContain('beta')
+          expect(version).not.toContain('rc')
+        })
+      },
+      LIVE_NETWORK_TIMEOUT_MS
+    )
   })
 })

--- a/test/integration/services.test.ts
+++ b/test/integration/services.test.ts
@@ -3,6 +3,12 @@ import { ChangelogFetcher } from '../../src/features/changelog'
 import { PACKAGE_NAME } from '../../src/shared/config/constants'
 import { fetchPackageVersions } from '../../src/shared/registry/npm-registry'
 
+// These tests hit the live npm registry. The retry stack alone can honestly
+// spend >10s on a struggling CI runner (backoff 0.5+1.5+3s between attempts,
+// plus connect stalls), so the budget must exceed that worst case — a 10s
+// budget made the first cold request a recurring single-runner flake.
+const LIVE_NETWORK_TIMEOUT_MS = 30_000
+
 describe('Services Integration Tests', () => {
   describe(`ChangelogFetcher with ${PACKAGE_NAME}`, () => {
     let fetcher: ChangelogFetcher
@@ -25,7 +31,7 @@ describe('Services Integration Tests', () => {
       expect(metadata?.repositoryUrl).toContain('github.com')
       expect(metadata?.npmUrl).toBe('https://www.npmjs.com/package/inup')
       expect(metadata?.license).toBeTruthy()
-    }, 10000)
+    }, LIVE_NETWORK_TIMEOUT_MS)
 
     it('should return null for nonexistent package', async () => {
       const metadata = await fetcher.fetchPackageMetadata(
@@ -33,7 +39,7 @@ describe('Services Integration Tests', () => {
       )
 
       expect(metadata).toBeNull()
-    }, 10000)
+    }, LIVE_NETWORK_TIMEOUT_MS)
 
     it('should use cache on second fetch', async () => {
       const packageVersion =
@@ -49,7 +55,7 @@ describe('Services Integration Tests', () => {
 
       // Second fetch should be significantly faster (cached)
       expect(duration2).toBeLessThan(duration1 / 2)
-    }, 10000)
+    }, LIVE_NETWORK_TIMEOUT_MS)
   })
 
   describe(`npm-registry with ${PACKAGE_NAME}`, () => {
@@ -62,7 +68,7 @@ describe('Services Integration Tests', () => {
       expect(testData?.latestVersion).toMatch(/^\d+\.\d+\.\d+$/)
       expect(testData?.allVersions.length).toBeGreaterThan(0)
       expect(testData?.allVersions[0]).toBe(testData?.latestVersion)
-    }, 10000)
+    }, LIVE_NETWORK_TIMEOUT_MS)
 
     it('should filter out pre-release versions', async () => {
       const result = await fetchPackageVersions([PACKAGE_NAME])
@@ -78,6 +84,6 @@ describe('Services Integration Tests', () => {
         expect(version).not.toContain('beta')
         expect(version).not.toContain('rc')
       })
-    }, 10000)
+    }, LIVE_NETWORK_TIMEOUT_MS)
   })
 })

--- a/test/unit/app/upgrade-runner.test.ts
+++ b/test/unit/app/upgrade-runner.test.ts
@@ -129,6 +129,68 @@ describe('UpgradeRunner terminal handoff', () => {
     })
   })
 
+  it('propagates the slowNetwork flag into the live progress object', async () => {
+    let seenProgress: { slowNetwork?: boolean } | undefined
+    const snapshotsAtBatch: (boolean | undefined)[] = []
+    mocks.selectPackagesToUpgradeProgressive.mockImplementation(
+      async (_states: unknown, progress: { slowNetwork?: boolean }) => {
+        seenProgress = progress
+        return []
+      }
+    )
+    mocks.appendOutdatedBatchToSelectionStates.mockImplementation(() => {
+      snapshotsAtBatch.push(seenProgress?.slowNetwork)
+    })
+    mocks.streamOutdatedPackages.mockImplementation(async (onEvent: any) => {
+      onEvent({
+        type: 'initial',
+        payload: {
+          allDependencies: [],
+          uniquePackages: ['next'],
+          currentVersions: new Map(),
+          progress: { discovered: 1, resolved: 0, total: 1, failed: 0, isLoading: true },
+        },
+      })
+      onEvent({
+        type: 'batch',
+        payload: {
+          batch: [],
+          progress: {
+            discovered: 1,
+            resolved: 1,
+            total: 1,
+            failed: 0,
+            isLoading: true,
+            slowNetwork: true,
+          },
+        },
+      })
+      onEvent({
+        type: 'complete',
+        payload: {
+          packages: [],
+          progress: {
+            discovered: 1,
+            resolved: 1,
+            total: 1,
+            failed: 0,
+            isLoading: false,
+            slowNetwork: false,
+          },
+        },
+      })
+    })
+    mocks.getOutdatedPackagesOnly.mockReturnValue([])
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    await new UpgradeRunner({ cwd: '/repo' }).run()
+    logSpy.mockRestore()
+
+    // The UI holds one live progress object; the hint must arrive through it.
+    expect(snapshotsAtBatch).toEqual([true])
+    expect(seenProgress?.slowNetwork).toBe(false) // and clear again on recovery
+  })
+
   it('exits early with up-to-date message when no outdated packages', async () => {
     mocks.streamOutdatedPackages.mockImplementation(async (onEvent: any) => {
       onEvent({

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -7,10 +7,14 @@ const mocks = vi.hoisted(() => ({
   checkForUpdateAsync: vi.fn(),
   getGitWorkingTreeState: vi.fn(),
   promptForImmediateConfirmation: vi.fn(),
+  upgradeRunnerOptions: [] as unknown[],
 }))
 
 vi.mock('../../src/index', () => ({
   UpgradeRunner: class {
+    constructor(options: unknown) {
+      mocks.upgradeRunnerOptions.push(options)
+    }
     run = mocks.upgradeRunnerRun
   },
 }))
@@ -225,5 +229,64 @@ describe('CLI headless routing', () => {
       target: 'latest',
     })
     expect(mocks.upgradeRunnerRun).not.toHaveBeenCalled()
+  })
+})
+
+describe('CLI concurrency flag', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.upgradeRunnerOptions.length = 0
+    setInteractive(true)
+    delete process.env.CI
+
+    mocks.loadProjectConfig.mockReturnValue({})
+    mocks.checkForUpdateAsync.mockResolvedValue(null)
+    mocks.getGitWorkingTreeState.mockReturnValue({ isRepo: false, isDirty: false })
+    mocks.upgradeRunnerRun.mockResolvedValue(undefined)
+    mocks.headlessRun.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: originalIsTTY, configurable: true })
+    if (originalCI === undefined) delete process.env.CI
+    else process.env.CI = originalCI
+  })
+
+  const baseOptions = { dir: '/repo', exclude: '', ignore: '', maxDepth: '10' }
+  const runnerOptions = () => mocks.upgradeRunnerOptions[0] as { concurrency?: number }
+
+  it('passes --concurrency through to the runner options', async () => {
+    await runCli({ ...baseOptions, concurrency: '6' })
+    expect(runnerOptions().concurrency).toBe(6)
+  })
+
+  it('leaves concurrency undefined when neither flag nor config sets it', async () => {
+    await runCli(baseOptions)
+    expect(runnerOptions().concurrency).toBeUndefined()
+  })
+
+  it('falls back to the .inuprc concurrency field', async () => {
+    mocks.loadProjectConfig.mockReturnValue({ concurrency: 4 })
+    await runCli(baseOptions)
+    expect(runnerOptions().concurrency).toBe(4)
+  })
+
+  it('prefers the flag over the .inuprc field', async () => {
+    mocks.loadProjectConfig.mockReturnValue({ concurrency: 4 })
+    await runCli({ ...baseOptions, concurrency: '2' })
+    expect(runnerOptions().concurrency).toBe(2)
+  })
+
+  it.each(['0', 'abc', '99', '7.5'])('rejects invalid --concurrency %s', async (raw) => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit')
+    }) as never)
+
+    await expect(runCli({ ...baseOptions, concurrency: raw })).rejects.toThrow('process.exit')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+
+    errorSpy.mockRestore()
+    exitSpy.mockRestore()
   })
 })

--- a/test/unit/features/debug/perf-logger.test.ts
+++ b/test/unit/features/debug/perf-logger.test.ts
@@ -57,6 +57,8 @@ describe('perfEnv', () => {
     expect(perfEnv()).toMatchObject({ INUP_ADAPTIVE: '0', INUP_PERF: '1' })
     expect(Object.keys(perfEnv())).toEqual([
       'INUP_ADAPTIVE',
+      'INUP_CONTROLLER',
+      'INUP_NET_PROFILE',
       'INUP_PERF',
       'INUP_DEBUG',
       'CI',

--- a/test/unit/features/interactive/package-list.test.ts
+++ b/test/unit/features/interactive/package-list.test.ts
@@ -514,6 +514,30 @@ describe('renderInterface body', () => {
 
     expect(text).not.toContain('Loading packages')
   })
+
+  it('flags a slow connection on the loading line', () => {
+    const text = renderPlain([baseState], {
+      loadingProgress: {
+        discovered: 50,
+        resolved: 12,
+        total: 50,
+        failed: 0,
+        isLoading: true,
+        slowNetwork: true,
+      },
+    })
+
+    expect(text).toContain('Loading packages... (12/50 checked)')
+    expect(text).toContain('slow connection, reduced parallelism')
+  })
+
+  it('does not mention the connection when it is not slow', () => {
+    const text = renderPlain([baseState], {
+      loadingProgress: { discovered: 5, resolved: 2, total: 5, failed: 0, isLoading: true },
+    })
+
+    expect(text).not.toContain('slow connection')
+  })
 })
 
 describe('renderPackagesTable', () => {

--- a/test/unit/features/interactive/package-list.test.ts
+++ b/test/unit/features/interactive/package-list.test.ts
@@ -34,6 +34,7 @@ interface RenderOptions {
   loadingProgress?: Parameters<typeof renderInterface>[12]
   auditProgress?: Parameters<typeof renderInterface>[13]
   notice?: string | null
+  terminalWidth?: number
 }
 
 function renderPlain(states = [baseState], opts: RenderOptions = {}): string {
@@ -49,7 +50,7 @@ function renderPlain(states = [baseState], opts: RenderOptions = {}): string {
     opts.filterMode,
     opts.filterQuery,
     opts.totalPackagesBeforeFilter,
-    120,
+    opts.terminalWidth ?? 120,
     opts.loadingProgress,
     opts.auditProgress,
     undefined,
@@ -537,6 +538,27 @@ describe('renderInterface body', () => {
     })
 
     expect(text).not.toContain('slow connection')
+  })
+
+  it('drops the slow-connection hint before overflowing a narrow terminal', () => {
+    const width = 60
+    const text = renderPlain([baseState], {
+      terminalWidth: width,
+      loadingProgress: {
+        discovered: 100,
+        resolved: 42,
+        total: 100,
+        failed: 3,
+        isLoading: true,
+        slowNetwork: true,
+      },
+    })
+
+    // The hint is informational; the loading line is not allowed to wrap.
+    expect(text).not.toContain('slow connection')
+    const loadingLine = text.split('\n').find((line) => line.includes('Loading packages'))
+    expect(loadingLine).toBeDefined()
+    expect(loadingLine!.length).toBeLessThanOrEqual(width)
   })
 })
 

--- a/test/unit/features/interactive/renderer/performance-modal.test.ts
+++ b/test/unit/features/interactive/renderer/performance-modal.test.ts
@@ -77,6 +77,31 @@ describe('renderPerformanceModal', () => {
     expect(text).toMatch(/Final EWMA\s+250 ms/)
     expect(text).toMatch(/Control ticks\s+3/)
     expect(text).toMatch(/Hard back-offs\s+1/)
+    // Plain AIMD ticks carry no state — the modal labels the arm accordingly.
+    expect(text).toMatch(/Controller\s+aimd/)
+  })
+
+  it('shows hill-climb state and goodput when the ticks carry them', () => {
+    const snapshot = makeSnapshot({
+      controlTicks: [
+        { atMs: 0, limit: 8, ewmaMs: 700, retries: 0, reason: 'double', state: 'slow-start' },
+        {
+          atMs: 5,
+          limit: 5,
+          ewmaMs: 800,
+          retries: 0,
+          reason: 'step-down',
+          state: 'hold',
+          goodputRps: 9.5,
+          revalidatedRatio: 0,
+        },
+      ],
+    })
+    const text = plain(renderPerformanceModal(snapshot, 100, 60).lines)
+
+    expect(text).toMatch(/Controller\s+hillclimb/)
+    expect(text).toMatch(/State\s+hold/)
+    expect(text).toMatch(/Last goodput\s+9\.5\/s/)
   })
 
   it('lists each failed package with a cross mark', () => {

--- a/test/unit/features/interactive/renderer/performance-modal.test.ts
+++ b/test/unit/features/interactive/renderer/performance-modal.test.ts
@@ -104,6 +104,22 @@ describe('renderPerformanceModal', () => {
     expect(text).toMatch(/Last goodput\s+9\.5\/s/)
   })
 
+  it('renders placeholders when the final hill-climb tick carries no window data', () => {
+    // Defensive rendering: snapshots may come from perf logs written by other
+    // versions, where a final hard-down tick has neither state nor goodput.
+    const snapshot = makeSnapshot({
+      controlTicks: [
+        { atMs: 0, limit: 8, ewmaMs: 700, retries: 0, reason: 'double', state: 'slow-start' },
+        { atMs: 5, limit: 4, ewmaMs: 900, retries: 1, reason: 'hard-down' },
+      ],
+    })
+    const text = plain(renderPerformanceModal(snapshot, 100, 60).lines)
+
+    expect(text).toMatch(/Controller\s+hillclimb/) // any state-carrying tick decides the arm
+    expect(text).toMatch(/State\s+—/)
+    expect(text).toMatch(/Last goodput\s+—/)
+  })
+
   it('lists each failed package with a cross mark', () => {
     const snapshot = makeSnapshot({ failedPackages: ['left-pad', 'is-odd'] })
     const text = plain(renderPerformanceModal(snapshot, 100, 60).lines)

--- a/test/unit/features/upgrade/package-detector.test.ts
+++ b/test/unit/features/upgrade/package-detector.test.ts
@@ -942,4 +942,49 @@ describe('PackageDetector concurrency plumbing', () => {
       profileLearnedLimit: 6,
     })
   })
+
+  const streamWithTick = async (tick: Record<string, unknown>) => {
+    const flags: (boolean | undefined)[] = []
+    const data = { latestVersion: '2.0.0', allVersions: ['2.0.0'] }
+    mocks.fetchPackageVersions.mockImplementation(
+      async (packageNames: string[], options: Record<string, any>) => {
+        options.onControlTick(tick)
+        options.onBatchReady([
+          { packageName: 'zod', data, completed: 1, total: 1, batchIndex: 0, itemIndex: 0 },
+        ])
+        return new Map([['zod', data]])
+      }
+    )
+    const detector = new PackageDetector({ cwd: '/repo' })
+    await detector.streamOutdatedPackages((event) => {
+      if (event.type === 'batch') flags.push(event.payload.progress.slowNetwork)
+    })
+    return flags
+  }
+
+  it('marks progress slowNetwork when the controller settled low', async () => {
+    const flags = await streamWithTick({
+      atMs: 1,
+      limit: 4,
+      ewmaMs: 300,
+      retries: 0,
+      reason: 'step-down',
+      state: 'hold',
+      goodputRps: 8,
+    })
+    expect(flags).toEqual([true])
+  })
+
+  it('leaves slowNetwork false on a healthy link', async () => {
+    const flags = await streamWithTick({
+      atMs: 1,
+      limit: 24,
+      ewmaMs: 40,
+      retries: 0,
+      reason: 'hold',
+      state: 'hold',
+      goodputRps: 300,
+    })
+    expect(flags).toEqual([false])
+  })
 })

--- a/test/unit/features/upgrade/package-detector.test.ts
+++ b/test/unit/features/upgrade/package-detector.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   getNetworkProfile: vi.fn(() => null),
   setNetworkProfile: vi.fn(),
   performanceTracker: {
+    mark: vi.fn(),
     recordControlTick: vi.fn(),
     recordPackageTiming: vi.fn(),
     recordFailedPackage: vi.fn(),
@@ -947,7 +948,7 @@ describe('PackageDetector concurrency plumbing', () => {
     const flags: (boolean | undefined)[] = []
     const data = { latestVersion: '2.0.0', allVersions: ['2.0.0'] }
     mocks.fetchPackageVersions.mockImplementation(
-      async (packageNames: string[], options: Record<string, any>) => {
+      async (_packageNames: string[], options: Record<string, any>) => {
         options.onControlTick(tick)
         options.onBatchReady([
           { packageName: 'zod', data, completed: 1, total: 1, batchIndex: 0, itemIndex: 0 },
@@ -986,5 +987,19 @@ describe('PackageDetector concurrency plumbing', () => {
       goodputRps: 300,
     })
     expect(flags).toEqual([false])
+  })
+
+  it('marks the firstBatch phase when the first batch streams in', async () => {
+    mocks.performanceTracker.mark.mockClear()
+    await streamWithTick({
+      atMs: 1,
+      limit: 24,
+      ewmaMs: 40,
+      retries: 0,
+      reason: 'hold',
+      state: 'hold',
+      goodputRps: 300,
+    })
+    expect(mocks.performanceTracker.mark).toHaveBeenCalledWith('firstBatch')
   })
 })

--- a/test/unit/features/upgrade/package-detector.test.ts
+++ b/test/unit/features/upgrade/package-detector.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   findPackageJson: vi.fn(),
@@ -9,6 +9,8 @@ const mocks = vi.hoisted(() => ({
   fetchPackageVersions: vi.fn(),
   loadPnpmCatalogs: vi.fn(),
   isPerfLoggingEnabled: vi.fn(() => false),
+  getNetworkProfile: vi.fn(() => null),
+  setNetworkProfile: vi.fn(),
   performanceTracker: {
     recordControlTick: vi.fn(),
     recordPackageTiming: vi.fn(),
@@ -74,6 +76,14 @@ vi.mock('../../../../src/shared/terminal', () => ({
   ConsoleUtils: {
     showProgress: vi.fn(),
     clearProgress: vi.fn(),
+  },
+}))
+
+// Keep the detector's profile read/write away from the user's real config.
+vi.mock('../../../../src/shared/config/user-config', () => ({
+  configManager: {
+    getNetworkProfile: mocks.getNetworkProfile,
+    setNetworkProfile: mocks.setNetworkProfile,
   },
 }))
 
@@ -457,6 +467,10 @@ describe('PackageDetector edge paths', () => {
       maxConcurrency: 10,
       batchSize: 10,
       poolConnections: expect.any(Number),
+      controllerMode: 'hillclimb',
+      pinnedConcurrency: null,
+      hadNetworkProfile: false,
+      profileLearnedLimit: null,
     })
   })
 
@@ -819,5 +833,113 @@ describe('PackageDetector edge paths', () => {
     await expect(detector.streamOutdatedPackages(() => {})).rejects.toThrow(
       /Failed to scan for package\.json files: .*sync boom/
     )
+  })
+})
+
+describe('PackageDetector concurrency plumbing', () => {
+  const originalController = process.env.INUP_CONTROLLER
+  const originalNetProfile = process.env.INUP_NET_PROFILE
+
+  const storedProfile = {
+    schemaVersion: 1 as const,
+    learnedLimit: 6,
+    baselineLatencyMs: 350,
+    baselineGoodputRps: 8.5,
+    sampleCount: 120,
+    updatedAt: new Date().toISOString(),
+  }
+
+  let fetchOptions: Record<string, unknown>
+
+  beforeEach(() => {
+    delete process.env.INUP_CONTROLLER
+    delete process.env.INUP_NET_PROFILE
+    mocks.getNetworkProfile.mockReset()
+    mocks.getNetworkProfile.mockReturnValue(null)
+    mocks.setNetworkProfile.mockReset()
+    mocks.loadPnpmCatalogs.mockReturnValue(null)
+    mocks.findPackageJson.mockReturnValue('/repo/package.json')
+    mocks.readPackageJson.mockReturnValue({ name: 'fixture' })
+    mocks.findAllPackageJsonFilesAsync.mockResolvedValue(['/repo/package.json'])
+    mocks.collectAllDependenciesAsync.mockResolvedValue([
+      {
+        name: 'zod',
+        version: '^1.0.0',
+        type: 'dependencies',
+        packageJsonPath: '/repo/package.json',
+      },
+    ])
+    mocks.findClosestMinorVersion.mockImplementation(
+      (version: string, versions: string[]) => versions[0] ?? version
+    )
+    mocks.fetchPackageVersions.mockReset()
+    mocks.fetchPackageVersions.mockImplementation(
+      async (_packageNames: string[], options: Record<string, unknown>) => {
+        fetchOptions = options
+        return new Map()
+      }
+    )
+  })
+
+  afterEach(() => {
+    if (originalController === undefined) delete process.env.INUP_CONTROLLER
+    else process.env.INUP_CONTROLLER = originalController
+    if (originalNetProfile === undefined) delete process.env.INUP_NET_PROFILE
+    else process.env.INUP_NET_PROFILE = originalNetProfile
+  })
+
+  const run = async (options?: ConstructorParameters<typeof PackageDetector>[0]) => {
+    const detector = new PackageDetector({ cwd: '/repo', ...options })
+    await detector.streamOutdatedPackages(() => {})
+    return detector
+  }
+
+  it('passes a pinned concurrency through to the registry fetcher', async () => {
+    await run({ concurrency: 5 })
+    expect(fetchOptions.concurrency).toBe(5)
+  })
+
+  it('defaults to the hillclimb controller', async () => {
+    await run()
+    expect(fetchOptions.controllerMode).toBe('hillclimb')
+  })
+
+  it('INUP_CONTROLLER=aimd selects the control arm', async () => {
+    process.env.INUP_CONTROLLER = 'aimd'
+    await run()
+    expect(fetchOptions.controllerMode).toBe('aimd')
+  })
+
+  it('injects the stored network profile', async () => {
+    mocks.getNetworkProfile.mockReturnValue(storedProfile)
+    await run()
+    expect(fetchOptions.networkProfile).toEqual(storedProfile)
+  })
+
+  it('persists the settled profile via onNetworkProfile', async () => {
+    await run()
+    const onNetworkProfile = fetchOptions.onNetworkProfile as (p: unknown) => void
+    expect(onNetworkProfile).toBeTypeOf('function')
+    onNetworkProfile(storedProfile)
+    expect(mocks.setNetworkProfile).toHaveBeenCalledWith(storedProfile)
+  })
+
+  it('INUP_NET_PROFILE=0 disables both profile read and write', async () => {
+    process.env.INUP_NET_PROFILE = '0'
+    mocks.getNetworkProfile.mockReturnValue(storedProfile)
+    await run()
+    expect(fetchOptions.networkProfile).toBeNull()
+    expect(fetchOptions.onNetworkProfile).toBeUndefined()
+  })
+
+  it('exposes the new knobs in the perf config', async () => {
+    mocks.getNetworkProfile.mockReturnValue(storedProfile)
+    const detector = await run({ concurrency: 7 })
+    expect(detector.getPerfConfig()).toMatchObject({
+      controllerMode: 'hillclimb',
+      pinnedConcurrency: 7,
+      hadNetworkProfile: true,
+      profileLearnedLimit: 6,
+    })
   })
 })

--- a/test/unit/shared/config/project-config.test.ts
+++ b/test/unit/shared/config/project-config.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { isPackageIgnored, loadProjectConfig } from '../../../../src/shared/config/project-config'
 
 describe('project-config', () => {
@@ -133,9 +133,24 @@ describe('project-config', () => {
       ['negative', '-3'],
       ['above pool', '99'],
       ['fractional', '7.5'],
-    ])('drops an invalid concurrency value (%s)', (_label, raw) => {
+    ])('drops an invalid concurrency value (%s) and says so', (_label, raw) => {
+      // Silent dropping would invert the user's intent: they pinned a low limit
+      // to protect a slow/metered link, and the run would adapt up to 24.
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
       writeFileSync(join(testDir, '.inuprc'), `{"concurrency": ${raw}}`)
       expect(loadProjectConfig(testDir).concurrency).toBeUndefined()
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('concurrency'))
+      warn.mockRestore()
+    })
+
+    it('does not warn when concurrency is valid or absent', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      writeFileSync(join(testDir, '.inuprc'), JSON.stringify({ concurrency: 8 }))
+      loadProjectConfig(testDir)
+      writeFileSync(join(testDir, '.inuprc'), JSON.stringify({ ignore: [] }))
+      loadProjectConfig(testDir)
+      expect(warn).not.toHaveBeenCalled()
+      warn.mockRestore()
     })
   })
 

--- a/test/unit/shared/config/project-config.test.ts
+++ b/test/unit/shared/config/project-config.test.ts
@@ -121,6 +121,24 @@ describe('project-config', () => {
     })
   })
 
+  describe('concurrency field', () => {
+    it('accepts an integer concurrency within the pool range', () => {
+      writeFileSync(join(testDir, '.inuprc'), JSON.stringify({ concurrency: 8 }))
+      expect(loadProjectConfig(testDir).concurrency).toBe(8)
+    })
+
+    it.each([
+      ['"8"', '"8"'],
+      ['zero', '0'],
+      ['negative', '-3'],
+      ['above pool', '99'],
+      ['fractional', '7.5'],
+    ])('drops an invalid concurrency value (%s)', (_label, raw) => {
+      writeFileSync(join(testDir, '.inuprc'), `{"concurrency": ${raw}}`)
+      expect(loadProjectConfig(testDir).concurrency).toBeUndefined()
+    })
+  })
+
   describe('isPackageIgnored()', () => {
     it('should match exact package names', () => {
       expect(isPackageIgnored('lodash', ['lodash'])).toBe(true)

--- a/test/unit/shared/config/user-config.test.ts
+++ b/test/unit/shared/config/user-config.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -139,6 +139,12 @@ describe('ConfigManager', () => {
       configManager.clearNetworkProfile()
       expect(configManager.getNetworkProfile()).toBeNull()
       expect(configManager.getTheme()).toBe('monokai')
+    })
+
+    it('clearNetworkProfile without a stored profile writes nothing', () => {
+      configManager.clearNetworkProfile()
+      // No profile to clear → no write → the config file is never created.
+      expect(existsSync(join(pathsMock.configDir, 'config.json'))).toBe(false)
     })
   })
 

--- a/test/unit/shared/config/user-config.test.ts
+++ b/test/unit/shared/config/user-config.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'nod
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { PersistedFilters } from '../../../../src/shared/types'
+import type { NetworkProfile, PersistedFilters } from '../../../../src/shared/types'
 
 // Redirect the env-paths config directory into a per-test temp dir so the
 // singleton never touches the user's real ~/.config/inup.
@@ -75,6 +75,71 @@ describe('ConfigManager', () => {
 
     expect(configManager.getTheme()).toBeNull()
     expect(error).toHaveBeenCalledWith('Error reading config:', expect.anything())
+  })
+
+  describe('network profile', () => {
+    const validProfile = (overrides: Partial<NetworkProfile> = {}): NetworkProfile => ({
+      schemaVersion: 1,
+      learnedLimit: 6,
+      baselineLatencyMs: 350,
+      baselineGoodputRps: 8.5,
+      sampleCount: 120,
+      updatedAt: new Date().toISOString(),
+      ...overrides,
+    })
+
+    it('returns null when no profile is stored', () => {
+      expect(configManager.getNetworkProfile()).toBeNull()
+    })
+
+    it('round-trips a profile through the config file', () => {
+      const profile = validProfile()
+      configManager.setNetworkProfile(profile)
+      expect(configManager.getNetworkProfile()).toEqual(profile)
+    })
+
+    it('coexists with the theme in the same file', () => {
+      configManager.setTheme('dracula')
+      configManager.setNetworkProfile(validProfile())
+      expect(configManager.getTheme()).toBe('dracula')
+      expect(configManager.getNetworkProfile()).not.toBeNull()
+    })
+
+    it('expires profiles older than 7 days (networks move; stale hints mislead)', () => {
+      const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString()
+      configManager.setNetworkProfile(validProfile({ updatedAt: eightDaysAgo }))
+      expect(configManager.getNetworkProfile()).toBeNull()
+    })
+
+    it('rejects a profile with an unknown schema version', () => {
+      configManager.setNetworkProfile(validProfile({ schemaVersion: 2 as unknown as 1 }))
+      expect(configManager.getNetworkProfile()).toBeNull()
+    })
+
+    it('rejects out-of-range or non-integer learned limits', () => {
+      for (const learnedLimit of [0, -1, 99, 7.5, Number.NaN]) {
+        configManager.setNetworkProfile(validProfile({ learnedLimit }))
+        expect(configManager.getNetworkProfile()).toBeNull()
+      }
+    })
+
+    it('rejects a non-finite baseline latency', () => {
+      configManager.setNetworkProfile(validProfile({ baselineLatencyMs: Number.POSITIVE_INFINITY }))
+      expect(configManager.getNetworkProfile()).toBeNull()
+    })
+
+    it('rejects an unparsable timestamp', () => {
+      configManager.setNetworkProfile(validProfile({ updatedAt: 'not a date' }))
+      expect(configManager.getNetworkProfile()).toBeNull()
+    })
+
+    it('clearNetworkProfile removes only the profile', () => {
+      configManager.setTheme('monokai')
+      configManager.setNetworkProfile(validProfile())
+      configManager.clearNetworkProfile()
+      expect(configManager.getNetworkProfile()).toBeNull()
+      expect(configManager.getTheme()).toBe('monokai')
+    })
   })
 
   it('swallows write failures and reports them', async () => {

--- a/test/unit/shared/config/user-config.test.ts
+++ b/test/unit/shared/config/user-config.test.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -131,6 +139,23 @@ describe('ConfigManager', () => {
     it('rejects an unparsable timestamp', () => {
       configManager.setNetworkProfile(validProfile({ updatedAt: 'not a date' }))
       expect(configManager.getNetworkProfile()).toBeNull()
+    })
+
+    it('rejects a timestamp far in the future (clock skew must not defeat expiry)', () => {
+      const threeDaysAhead = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString()
+      configManager.setNetworkProfile(validProfile({ updatedAt: threeDaysAhead }))
+      expect(configManager.getNetworkProfile()).toBeNull()
+    })
+
+    it('writes atomically: no temp files survive and the JSON is always complete', () => {
+      configManager.setTheme('dracula')
+      configManager.setNetworkProfile(validProfile())
+      const entries = readdirSync(pathsMock.configDir)
+      expect(entries).toEqual(['config.json'])
+      // The file on disk is complete, parseable JSON with every key intact.
+      const raw = JSON.parse(readFileSync(join(pathsMock.configDir, 'config.json'), 'utf8'))
+      expect(raw.theme).toBe('dracula')
+      expect(raw.networkProfile.schemaVersion).toBe(1)
     })
 
     it('clearNetworkProfile removes only the profile', () => {

--- a/test/unit/shared/http/hill-climb-controller.test.ts
+++ b/test/unit/shared/http/hill-climb-controller.test.ts
@@ -332,9 +332,33 @@ describe('HillClimbController', () => {
       expect(reasons(h)).not.toContain('regime-reset')
     })
 
-    it('keeps the learned limit when the network got faster (doubling handles it)', () => {
+    it('resets on a drastically FASTER network too (a stuck-low profile would drag a fast link)', () => {
+      // Symmetric regime check: from a profile the controller starts gated, so
+      // two windows at the same limit read as a plateau and it would climb DOWN
+      // from a learned slow-café limit even on fast home wifi. A much-better
+      // regime therefore discards the profile and re-learns via cold slow-start.
       const h = makeController({ profile: { learnedLimit: 8, baselineLatencyMs: 400 } })
-      feed(h.c, T.validateAfterCompletions, 20)
+      const immediate = feed(h.c, T.validateAfterCompletions, 20)
+      expect(immediate).toBe(T.coldStart)
+      expect(reasons(h)).toContain('regime-reset')
+      // Cold restart re-arms the blind double: fast links reach the ceiling in
+      // 3 windows instead of crawling up by probe.
+      closeWindow(h, 1200)
+      expect(h.c.getLimit()).toBe(T.coldStart * 2)
+    })
+
+    it('keeps the profile when latency merely improved a little', () => {
+      // 150 → 100ms: below the better-regime delta — not worth re-learning.
+      const h = makeController({ profile: { learnedLimit: 8, baselineLatencyMs: 150 } })
+      feed(h.c, T.validateAfterCompletions, 100)
+      expect(h.c.getLimit()).toBe(8)
+      expect(reasons(h)).not.toContain('regime-reset')
+    })
+
+    it('keeps the profile when the improvement misses the ratio gate', () => {
+      // 400 → 160ms: big delta but not 3× better — same regime, keep the limit.
+      const h = makeController({ profile: { learnedLimit: 8, baselineLatencyMs: 400 } })
+      feed(h.c, T.validateAfterCompletions, 160)
       expect(h.c.getLimit()).toBe(8)
       expect(reasons(h)).not.toContain('regime-reset')
     })
@@ -356,5 +380,136 @@ describe('HillClimbController', () => {
       expect(tick.limit).toBe(8)
       expect(tick.atMs).toBe(START_AT + 1200)
     })
+  })
+})
+
+describe('HillClimbController unhappy paths', () => {
+  /** Close a window that contained one retryable error (11 successes + 1 error). */
+  const errorWindow = (h: Harness, elapsedMs = 1200): number | null => {
+    feed(h.c, T.windowCompletions - 1, 100)
+    h.c.record('retryable')
+    return h.c.maybeTick(h.clock.advance(elapsedMs))
+  }
+
+  it('a disconnect walks the limit down to the floor and never below', () => {
+    const h = makeController({})
+    closeWindow(h, 1200) // healthy: blind double → 8
+    expect(errorWindow(h)).toBe(6) // round(8 × 0.7)
+    expect(errorWindow(h)).toBe(4)
+    expect(errorWindow(h)).toBe(3) // floor
+    expect(errorWindow(h)).toBe(null) // clamped — no change, no underflow
+    expect(h.c.getLimit()).toBe(T.floor)
+    expect(
+      reasons(h)
+        .slice(1)
+        .every((r) => r === 'soft-down')
+    ).toBe(true)
+  })
+
+  it('recovers after a reconnect: floor → probes → climb back up', () => {
+    const h = makeController({})
+    closeWindow(h, 1200)
+    for (let i = 0; i < 4; i++) errorWindow(h) // disconnect: down to floor 3
+    expect(h.c.getLimit()).toBe(T.floor)
+
+    // Reconnect onto a fast, RTT-bound link: goodput ∝ limit (10/s per slot).
+    for (let i = 0; i < 40; i++) {
+      const limit = h.c.getLimit()
+      closeWindow(h, Math.max(1, Math.round(1200 / limit)))
+    }
+    expect(h.c.getLimit()).toBeGreaterThanOrEqual(10)
+    expect(reasons(h)).toContain('probe-up')
+    expect(reasons(h)).toContain('up')
+  })
+
+  it('congestion while a probe is pending cleans the probe up', () => {
+    const h = makeController({ profile: { learnedLimit: 8, baselineLatencyMs: 100 } })
+    feed(h.c, T.validateAfterCompletions, 100)
+    closeWindow(h, 1200, { count: 4 }) // baseline 10/s at 8
+    closeWindow(h, 1200) // plateau → 7, climb-down
+    closeWindow(h, 1371) // RTT-bound loss → revert to 8, HOLD
+    for (let i = 0; i < T.reprobeAfterWindows; i++) closeWindow(h, 1200)
+    expect(h.c.getLimit()).toBe(9) // probing
+
+    const immediate = h.c.record('congested')
+    expect(immediate).toBe(5) // round(9 × 0.5), applied now
+    expect(h.c.getState()).toBe('hold')
+
+    closeWindow(h, 1200)
+    // The abandoned probe must not be evaluated after the hard-down.
+    expect(h.ticks.at(-1)?.reason).toBe('hold')
+    expect(h.c.getLimit()).toBe(5)
+  })
+
+  it('repeated congestion at the floor stays clamped', () => {
+    const h = makeController({})
+    expect(h.c.record('congested')).toBe(T.floor) // round(4 × 0.5) = 2 → clamp 3
+    expect(h.c.record('congested')).toBe(T.floor)
+    expect(h.c.getLimit()).toBe(T.floor)
+  })
+
+  it('a pure latency spike in HOLD moves nothing (goodput is the only signal)', () => {
+    const h = makeController({ profile: { learnedLimit: 8, baselineLatencyMs: 100 } })
+    feed(h.c, T.validateAfterCompletions, 100)
+    closeWindow(h, 1200, { count: 4 })
+    closeWindow(h, 1200)
+    closeWindow(h, 1371) // HOLD at 8
+    h.ticks.length = 0
+
+    // Latency 50× worse, goodput unchanged: nothing may move.
+    for (let i = 0; i < 4; i++) closeWindow(h, 1200, { latencyMs: 5000 })
+    expect(h.c.getLimit()).toBe(8)
+    expect(h.ticks.every((t) => t.reason === 'hold')).toBe(true)
+  })
+
+  it('zero-elapsed windows do not produce NaN or unbounded limits', () => {
+    const h = makeController({})
+    closeWindow(h, 0)
+    closeWindow(h, 0)
+    expect(Number.isFinite(h.c.getLimit())).toBe(true)
+    expect(h.c.getLimit()).toBeLessThanOrEqual(T.ceil)
+    expect(h.ticks.every((t) => Number.isFinite(t.goodputRps ?? 0))).toBe(true)
+  })
+
+  it('a corrupt zero baseline cannot trigger a false regime reset', () => {
+    const h = makeController({ profile: { learnedLimit: 8, baselineLatencyMs: 0 } })
+    feed(h.c, T.validateAfterCompletions, 400)
+    // worse needs > max(3×0, 500) = 500ms; better needs baseline − ewma > 200.
+    expect(h.c.getLimit()).toBe(8)
+    expect(reasons(h)).not.toContain('regime-reset')
+  })
+
+  it('errors during validation abandon it without wedging the controller', () => {
+    const h = makeController({ profile: { learnedLimit: 16, baselineLatencyMs: 100 } })
+    feed(h.c, 4, 100) // validation under way (4 of 8)
+    for (let i = 0; i < 8; i++) h.c.record('retryable')
+    expect(h.c.maybeTick(h.clock.advance(1200))).toBe(11) // soft-down, validation over
+
+    // These would have failed the regime check — but validation was abandoned.
+    feed(h.c, T.validateAfterCompletions, 900)
+    expect(reasons(h)).not.toContain('regime-reset')
+    expect(h.c.getLimit()).toBe(11)
+
+    // And the controller still ticks normally afterwards.
+    closeWindow(h, 1200, { count: 4 })
+    expect(h.ticks.at(-1)?.reason).toBe('hold') // clean baseline window
+  })
+
+  it('congestion after freeze still applies but poisons no profile', () => {
+    const h = makeController({ profile: { learnedLimit: 8, baselineLatencyMs: 100 } })
+    feed(h.c, T.validateAfterCompletions, 100)
+    closeWindow(h, 1200, { count: 4 })
+    closeWindow(h, 1200)
+    closeWindow(h, 1371) // HOLD at 8, 36 completions
+    h.c.freeze()
+    expect(h.c.record('congested')).toBe(4) // the server signal still counts
+    expect(h.c.getSettledProfile(5_000_000)).toBeNull()
+  })
+
+  it('an all-304 warm-cache run still adapts on revalidation goodput', () => {
+    const h = makeController({})
+    closeWindow(h, 1200, { revalidatedCount: 12 }) // blind double → 8
+    closeWindow(h, 600, { revalidatedCount: 12 }) // same mix → comparable → 2× gain
+    expect(h.c.getLimit()).toBe(16)
   })
 })

--- a/test/unit/shared/http/hill-climb-controller.test.ts
+++ b/test/unit/shared/http/hill-climb-controller.test.ts
@@ -94,6 +94,32 @@ describe('HillClimbController', () => {
     })
   })
 
+  describe('tuning sanitization (experiment overrides)', () => {
+    it('rejects non-finite or non-positive knobs', () => {
+      expect(
+        () => new HillClimbController(300, { tuning: { windowCompletions: Number.NaN } })
+      ).toThrow(/windowCompletions/)
+      expect(() => new HillClimbController(300, { tuning: { floor: 0 } })).toThrow(/floor/)
+      expect(() => new HillClimbController(300, { tuning: { ewmaAlpha: -1 } })).toThrow(/ewmaAlpha/)
+    })
+
+    it('floors fractional bounds and never lets the ceiling drop below the floor', () => {
+      const c = new HillClimbController(300, { tuning: { floor: 2.9, ceil: 2.2, coldStart: 9.7 } })
+      // floor → 2, ceil → max(2, 2) = 2, so the cold start lands on 2.
+      expect(c.getLimit()).toBe(2)
+    })
+
+    it('floors a fractional window size to one completion and still ticks', () => {
+      const c = new HillClimbController(300, {
+        tuning: { windowCompletions: 0.9 },
+        startedAt: START_AT,
+      })
+      c.record('success', 100)
+      // One completion closes the window; the cold start blind-doubles 4 → 8.
+      expect(c.maybeTick(START_AT + 1000)).toBe(8)
+    })
+  })
+
   describe('slow start (cold)', () => {
     it('starts at coldStart and doubles to the ceiling while goodput keeps improving', () => {
       const h = makeController({})

--- a/test/unit/shared/http/hill-climb-controller.test.ts
+++ b/test/unit/shared/http/hill-climb-controller.test.ts
@@ -445,6 +445,7 @@ describe('HillClimbController unhappy paths', () => {
     expect(immediate).toBe(5) // round(9 × 0.5), applied now
     expect(h.c.getState()).toBe('hold')
 
+    closeWindow(h, 1200) // half-timed window after the hard-down: discarded
     closeWindow(h, 1200)
     // The abandoned probe must not be evaluated after the hard-down.
     expect(h.ticks.at(-1)?.reason).toBe('hold')
@@ -489,19 +490,21 @@ describe('HillClimbController unhappy paths', () => {
     expect(reasons(h)).not.toContain('regime-reset')
   })
 
-  it('errors during validation abandon it without wedging the controller', () => {
+  it('a soft-down during validation applies the decrease but keeps validating', () => {
     const h = makeController({ profile: { learnedLimit: 16, baselineLatencyMs: 100 } })
     feed(h.c, 4, 100) // validation under way (4 of 8)
     for (let i = 0; i < 8; i++) h.c.record('retryable')
-    expect(h.c.maybeTick(h.clock.advance(1200))).toBe(11) // soft-down, validation over
+    expect(h.c.maybeTick(h.clock.advance(1200))).toBe(11) // soft-down applies…
+    expect(h.c.getState()).toBe('validating') // …but the regime check survives
 
-    // These would have failed the regime check — but validation was abandoned.
-    feed(h.c, T.validateAfterCompletions, 900)
+    // Matching latency completes the check without a reset; state moves on.
+    feed(h.c, 4, 100)
     expect(reasons(h)).not.toContain('regime-reset')
     expect(h.c.getLimit()).toBe(11)
+    expect(h.c.getState()).toBe('slow-start')
 
     // And the controller still ticks normally afterwards.
-    closeWindow(h, 1200, { count: 4 })
+    closeWindow(h, 1200)
     expect(h.ticks.at(-1)?.reason).toBe('hold') // clean baseline window
   })
 
@@ -601,5 +604,122 @@ describe('HillClimbController coverage edges', () => {
     closeWindow(h, 1600)
     expect(h.c.getLimit()).toBe(T.floor)
     expect(reasons(h)).toEqual(['hold', 'hold'])
+  })
+})
+
+describe('HillClimbController review fixes', () => {
+  it('a soft-down forgets the pre-error revert point (no multi-slot jumps)', () => {
+    const h = makeController({})
+    closeWindow(h, 1200) // blind double 4 → 8
+    closeWindow(h, 600) // 2.0× → double 8 → 16, revert point = 8
+    feed(h.c, T.windowCompletions - 1, 100)
+    h.c.record('retryable')
+    expect(h.c.maybeTick(h.clock.advance(600))).toBe(11) // soft-down 16 × 0.7
+    closeWindow(h, 1200) // clean baseline window
+    const before = h.c.getLimit()
+    closeWindow(h, 1200) // flat: plateau — must step ±1, never snap to the stale 8
+    expect(before - h.c.getLimit()).toBeLessThanOrEqual(1)
+    expect(h.c.getLimit()).toBe(10)
+  })
+})
+
+describe('HillClimbController clock and mix safety (review fixes)', () => {
+  it('skips the decision when the clock did not move forward across the window', () => {
+    const h = makeController({})
+    expect(closeWindow(h, 0)).toBe(null) // zero elapsed: unmeasurable
+    expect(h.ticks).toHaveLength(0)
+    expect(closeWindow(h, -100)).toBe(null) // clock stepped backwards
+    expect(h.ticks).toHaveLength(0)
+    expect(h.c.getLimit()).toBe(T.coldStart)
+    // A normal window afterwards works and decides again.
+    expect(closeWindow(h, 1200)).toBe(8)
+  })
+
+  it('discards the half-timed window after a hard-down instead of mis-measuring it', () => {
+    const h = makeController({ profile: { learnedLimit: 16, baselineLatencyMs: 100 } })
+    feed(h.c, T.validateAfterCompletions, 100)
+    h.c.record('congested') // → 8, resets counters but cannot reset the window clock
+    h.ticks.length = 0
+    closeWindow(h, 30_000) // Retry-After pause inflated this window's elapsed time
+    expect(h.ticks).toHaveLength(0) // unmeasurable — no goodput may be derived from it
+    closeWindow(h, 1200) // the next full window is the clean baseline
+    expect(h.ticks).toHaveLength(1)
+    expect(h.ticks[0].reason).toBe('hold')
+    expect(h.ticks[0].goodputRps).toBeCloseTo(10, 1)
+  })
+
+  it('keeps validating through an errorful window (flaky links need the check most)', () => {
+    const h = makeController({ profile: { learnedLimit: 24, baselineLatencyMs: 100 } })
+    feed(h.c, 4, 900) // 4 slow full fetches — validation under way
+    for (let i = 0; i < 8; i++) h.c.record('retryable')
+    h.c.maybeTick(h.clock.advance(1200)) // soft-down 24 → 17
+    expect(h.c.getState()).toBe('validating') // NOT abandoned
+    const immediate = feed(h.c, 4, 900) // 8th full success completes the check
+    expect(immediate).toBe(T.coldStart) // 900ms vs 100ms baseline → regime reset
+    expect(reasons(h)).toContain('regime-reset')
+  })
+
+  it('revalidated (304) successes cannot fake a regime change', () => {
+    // Warm cache after a cold-learned profile: 304s are fast on ANY link, so
+    // they must neither trigger the "better" reset nor advance validation.
+    const h = makeController({ profile: { learnedLimit: 24, baselineLatencyMs: 700 } })
+    feed(h.c, 12, 80, 12) // a full window of 80ms 304s
+    h.c.maybeTick(h.clock.advance(1200))
+    expect(h.c.getState()).toBe('validating') // still undecided
+    expect(reasons(h)).not.toContain('regime-reset')
+    feed(h.c, 12, 80, 12)
+    h.c.maybeTick(h.clock.advance(1200))
+    // Two windows without enough full fetches: give up on the latency check
+    // and keep the learned limit — a warm run is cheap at any limit.
+    expect(h.c.getState()).toBe('slow-start')
+    expect(h.c.getLimit()).toBe(24)
+    expect(reasons(h)).not.toContain('regime-reset')
+  })
+
+  it('persists the FULL-FETCH latency as the baseline, not the 304-diluted mix', () => {
+    const h = makeController({ profile: { learnedLimit: 8, baselineLatencyMs: 700 } })
+    feed(h.c, T.validateAfterCompletions, 700) // full fetches at 700ms: same regime
+    const mixed = {
+      count: 12,
+      latencyMs: (i: number) => (i < 10 ? 80 : 700), // 10 fast 304s + 2 real fetches
+      revalidatedCount: 10,
+    }
+    closeWindow(h, 1200, { count: 4, latencyMs: 80, revalidatedCount: 4 }) // baseline window
+    closeWindow(h, 1200, mixed) // mix shifted → incomparable, rolls baseline
+    closeWindow(h, 1200, mixed) // plateau → 7, climb-down
+    closeWindow(h, 1371, mixed) // real loss → revert → HOLD at 8
+    h.c.freeze()
+
+    const profile = h.c.getSettledProfile(5_000_000)
+    expect(profile).not.toBeNull()
+    // All full fetches ran at 700ms; the 80ms 304s must not drag the baseline.
+    expect(profile?.baselineLatencyMs).toBe(700)
+  })
+
+  it('an all-304 run learns a limit but never persists a latency baseline', () => {
+    const h = makeController({})
+    const warm = { revalidatedCount: 12 }
+    closeWindow(h, 1200, warm) // blind double → 8
+    closeWindow(h, 1200, warm) // plateau → revert 4, climb-down
+    closeWindow(h, 1200, warm) // flat → 3 (floor)
+    closeWindow(h, 1200, warm) // settle → HOLD
+    expect(h.c.getState()).toBe('hold')
+    h.c.freeze()
+    // Zero full fetches → no trustworthy latency baseline → nothing to persist
+    // (a stored 304-based baseline would poison the next run's regime check).
+    expect(h.c.getSettledProfile(5_000_000)).toBeNull()
+  })
+
+  it('counts only successes toward the profile sample size', () => {
+    const h = makeController({ profile: { learnedLimit: 8, baselineLatencyMs: 100 } })
+    feed(h.c, T.validateAfterCompletions, 100)
+    closeWindow(h, 1200, { count: 4 })
+    closeWindow(h, 1200) // → 7
+    closeWindow(h, 1371) // → HOLD at 8 (36 successes so far)
+    feed(h.c, T.windowCompletions - 1, 100)
+    h.c.record('retryable') // 47 successes + 1 error
+    h.c.maybeTick(h.clock.advance(1200))
+    h.c.freeze()
+    expect(h.c.getSettledProfile(5_000_000)?.sampleCount).toBe(47)
   })
 })

--- a/test/unit/shared/http/hill-climb-controller.test.ts
+++ b/test/unit/shared/http/hill-climb-controller.test.ts
@@ -108,6 +108,16 @@ describe('HillClimbController', () => {
       expect(h.c.getState()).toBe('hold')
     })
 
+    it('downshifts from doubling to +1 climbing on a moderate gain', () => {
+      const h = makeController({})
+      expect(closeWindow(h, 1200)).toBe(8) // blind double, goodput 10/s
+      // 12/s: 1.2× — real improvement, but below the doubling gate. Doubling
+      // again would overshoot; probe upward one step at a time instead.
+      expect(closeWindow(h, 1000)).toBe(9)
+      expect(h.c.getState()).toBe('climb-up')
+      expect(h.ticks.at(-1)?.reason).toBe('up')
+    })
+
     it('reverts the last double and starts counting down when goodput plateaus', () => {
       const h = makeController({})
       expect(closeWindow(h, 1200)).toBe(8) // blind double, goodput 10/s
@@ -511,5 +521,85 @@ describe('HillClimbController unhappy paths', () => {
     closeWindow(h, 1200, { revalidatedCount: 12 }) // blind double → 8
     closeWindow(h, 600, { revalidatedCount: 12 }) // same mix → comparable → 2× gain
     expect(h.c.getLimit()).toBe(16)
+  })
+})
+
+describe('HillClimbController coverage edges', () => {
+  it('a success without a latency sample counts toward the window but decides nothing', () => {
+    const h = makeController({ profile: { learnedLimit: 8, baselineLatencyMs: 100 } })
+    expect(h.c.record('success')).toBe(null)
+    // No latency → no EWMA sample → validation must not be consumed by it.
+    expect(h.c.getState()).toBe('validating')
+  })
+
+  it('HOLD reached through congestion alone never yields a profile (sample-starved)', () => {
+    const h = makeController({})
+    h.c.record('congested') // forces HOLD with totalCompletions = 1
+    expect(h.c.getState()).toBe('hold')
+    expect(h.c.getSettledProfile(5_000_000)).toBeNull()
+  })
+
+  it('a soft-down before freeze degrades the profile goodput to 0, not the profile itself', () => {
+    const h = makeController({ profile: { learnedLimit: 8, baselineLatencyMs: 100 } })
+    feed(h.c, T.validateAfterCompletions, 100)
+    closeWindow(h, 1200, { count: 4 })
+    closeWindow(h, 1200) // plateau → 7
+    closeWindow(h, 1371) // revert → HOLD at 8
+    feed(h.c, T.windowCompletions - 1, 100)
+    h.c.record('retryable')
+    h.c.maybeTick(h.clock.advance(1200)) // soft-down clears the goodput baseline
+    h.c.freeze()
+
+    const profile = h.c.getSettledProfile(5_000_000)
+    expect(profile).not.toBeNull() // soft-downs do not poison the profile…
+    expect(profile?.baselineGoodputRps).toBe(0) // …but the goodput reading is gone
+  })
+
+  it('a cache-mix shift during a pending probe rejects the probe', () => {
+    const h = makeController({ profile: { learnedLimit: 8, baselineLatencyMs: 100 } })
+    feed(h.c, T.validateAfterCompletions, 100)
+    closeWindow(h, 1200, { count: 4 })
+    closeWindow(h, 1200)
+    closeWindow(h, 1371) // HOLD at 8
+    for (let i = 0; i < T.reprobeAfterWindows; i++) closeWindow(h, 1200)
+    expect(h.c.getLimit()).toBe(9) // probing
+
+    closeWindow(h, 1200, { revalidatedCount: 10 }) // 304 share jumps 0 → 0.83
+    expect(h.ticks.at(-1)?.reason).toBe('probe-reject')
+    expect(h.c.getLimit()).toBe(8)
+  })
+
+  it('climb-up ends with a revert to the knee when a +1 stops paying', () => {
+    const h = makeController({ profile: { learnedLimit: 8, baselineLatencyMs: 100 } })
+    feed(h.c, T.validateAfterCompletions, 100)
+    closeWindow(h, 1200, { count: 4 })
+    closeWindow(h, 1200)
+    closeWindow(h, 1371) // HOLD at 8, best 10/s
+    for (let i = 0; i < T.reprobeAfterWindows; i++) closeWindow(h, 1200)
+    closeWindow(h, 1000) // probe accepted: 12/s ≥ 1.05× → climb-up, limit 10
+    expect(h.c.getState()).toBe('climb-up')
+    expect(h.c.getLimit()).toBe(10)
+
+    closeWindow(h, 1000) // 12/s again: gain 1.0 < gainEpsilon → take the +1 back
+    expect(h.ticks.at(-1)?.reason).toBe('revert')
+    expect(h.c.getLimit()).toBe(9)
+    expect(h.c.getState()).toBe('hold')
+  })
+
+  it('a flat count-down lands on the floor and holds there', () => {
+    const h = makeController({ profile: { learnedLimit: 4, baselineLatencyMs: 100 } })
+    feed(h.c, T.validateAfterCompletions, 100)
+    closeWindow(h, 1200, { count: 4 }) // baseline at 4
+    closeWindow(h, 1200) // plateau → 3 (floor), climb-down
+    closeWindow(h, 1200) // still flat at the floor → settle
+    expect(h.c.getLimit()).toBe(T.floor)
+    expect(h.c.getState()).toBe('hold')
+
+    // Degraded windows at the floor must not push below it.
+    h.ticks.length = 0
+    closeWindow(h, 1600)
+    closeWindow(h, 1600)
+    expect(h.c.getLimit()).toBe(T.floor)
+    expect(reasons(h)).toEqual(['hold', 'hold'])
   })
 })

--- a/test/unit/shared/http/hill-climb-controller.test.ts
+++ b/test/unit/shared/http/hill-climb-controller.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, it } from 'vitest'
+import type { ControlTick } from '../../../../src/shared/http/adaptive-controller'
+import {
+  HILL_CLIMB_TUNING,
+  HillClimbController,
+} from '../../../../src/shared/http/hill-climb-controller'
+import type { NetworkProfile } from '../../../../src/shared/types/domain'
+
+// The default tuning, restated so the assertions below read as concrete math.
+const T = HILL_CLIMB_TUNING
+
+const START_AT = 1_000
+
+const makeClock = () => {
+  let t = START_AT
+  return {
+    now: () => t,
+    advance: (ms: number) => {
+      t += ms
+      return t
+    },
+  }
+}
+
+type Harness = {
+  c: HillClimbController
+  ticks: ControlTick[]
+  clock: ReturnType<typeof makeClock>
+}
+
+const makeController = (opts: {
+  packageCount?: number
+  profile?: Pick<NetworkProfile, 'learnedLimit' | 'baselineLatencyMs'> | null
+}): Harness => {
+  const ticks: ControlTick[] = []
+  const clock = makeClock()
+  const c = new HillClimbController(opts.packageCount ?? 300, {
+    profile: opts.profile ?? null,
+    onTick: (t) => ticks.push(t),
+    startedAt: START_AT,
+  })
+  return { c, ticks, clock }
+}
+
+/** Record `count` successes; returns the last immediate limit change (if any). */
+const feed = (
+  c: HillClimbController,
+  count: number,
+  latencyMs: number | ((i: number) => number) = 100,
+  revalidatedCount = 0
+): number | null => {
+  let last: number | null = null
+  for (let i = 0; i < count; i++) {
+    const latency = typeof latencyMs === 'function' ? latencyMs(i) : latencyMs
+    const next = c.record('success', latency, { revalidated: i < revalidatedCount })
+    if (next !== null) last = next
+  }
+  return last
+}
+
+/**
+ * Close one goodput window: feed `count` completions (default: a full window),
+ * advance the clock by `elapsedMs`, and tick. Window goodput is therefore
+ * `windowCompletions / (elapsedMs / 1000)` when the window had a full 12.
+ */
+const closeWindow = (
+  h: Harness,
+  elapsedMs: number,
+  opts: {
+    count?: number
+    latencyMs?: number | ((i: number) => number)
+    revalidatedCount?: number
+  } = {}
+): number | null => {
+  feed(h.c, opts.count ?? T.windowCompletions, opts.latencyMs ?? 100, opts.revalidatedCount ?? 0)
+  return h.c.maybeTick(h.clock.advance(elapsedMs))
+}
+
+const reasons = (h: Harness) => h.ticks.map((t) => t.reason)
+
+describe('HillClimbController', () => {
+  describe('shouldControl', () => {
+    it('requires at least 30 packages (2 windows + tail headroom)', () => {
+      expect(HillClimbController.shouldControl(29)).toBe(false)
+      expect(HillClimbController.shouldControl(30)).toBe(true)
+    })
+  })
+
+  describe('tuning invariants', () => {
+    it('keeps the ceiling equal to the pool connection count', () => {
+      expect(T.ceil).toBe(24)
+      expect(T.floor).toBe(3)
+      expect(T.coldStart).toBe(4)
+    })
+  })
+
+  describe('slow start (cold)', () => {
+    it('starts at coldStart and doubles to the ceiling while goodput keeps improving', () => {
+      const h = makeController({})
+      expect(h.c.getLimit()).toBe(T.coldStart)
+
+      // First window has no baseline: cold start doubles blindly (a wrong guess
+      // costs one window; the next gate catches it).
+      expect(closeWindow(h, 1200)).toBe(8) // goodput 10/s
+      expect(closeWindow(h, 600)).toBe(16) // goodput 20/s → 2.0× ≥ strongGainFactor
+      expect(closeWindow(h, 300)).toBe(24) // goodput 40/s → 2.0× → 2×16 clamped to ceil
+      expect(reasons(h)).toEqual(['double', 'double', 'double'])
+      expect(h.c.getState()).toBe('hold')
+    })
+
+    it('reverts the last double and starts counting down when goodput plateaus', () => {
+      const h = makeController({})
+      expect(closeWindow(h, 1200)).toBe(8) // blind double, goodput 10/s
+      // Same goodput at twice the parallelism: the pipe is saturated.
+      expect(closeWindow(h, 1200)).toBe(4) // gain 1.0 < gainEpsilon → revert
+      expect(reasons(h)).toEqual(['double', 'revert'])
+      expect(h.c.getState()).toBe('climb-down')
+    })
+
+    it('ignores per-request latency jitter while window goodput is stable (no oscillation)', () => {
+      const h = makeController({})
+      const jitter = (i: number) => (i % 2 === 0 ? 1 : 25)
+      closeWindow(h, 1200, { latencyMs: jitter }) // → 8
+      closeWindow(h, 480, { latencyMs: jitter }) // 25/s, 2.5× → 16
+      closeWindow(h, 260, { latencyMs: jitter }) // 46/s → 24 (ceil)
+      for (let i = 0; i < 7; i++) {
+        closeWindow(h, 220, { latencyMs: jitter }) // stable ~54.5/s
+      }
+      expect(h.c.getLimit()).toBe(24)
+      const downs = reasons(h).filter((r) =>
+        ['step-down', 'revert', 'soft-down', 'hard-down'].includes(r)
+      )
+      expect(downs).toEqual([])
+    })
+  })
+
+  describe('climb-down (the 7→6→5 count-down)', () => {
+    it('steps down while goodput stays flat and reverts on the first real loss', () => {
+      // Start from a learned limit of 8 so the numbers match the user scenario.
+      const h = makeController({ profile: { learnedLimit: 8, baselineLatencyMs: 100 } })
+      feed(h.c, T.validateAfterCompletions, 100) // validation passes (100ms ≈ baseline)
+      expect(h.c.getLimit()).toBe(8)
+
+      // First window from a profile establishes a baseline — no blind double.
+      expect(closeWindow(h, 1200, { count: 4 })).toBe(null) // 12 total (8 validation + 4)
+      expect(h.ticks[0].reason).toBe('hold')
+
+      expect(closeWindow(h, 1200)).toBe(7) // plateau at same limit → start descending
+      expect(h.c.getState()).toBe('climb-down')
+      expect(closeWindow(h, 1220)).toBe(6) // 9.84/s vs 10/s = 0.984 ≥ keepDownEpsilon
+      expect(closeWindow(h, 1230)).toBe(5) // 9.76/s vs 9.84/s = 0.992 ≥ keepDownEpsilon
+      expect(closeWindow(h, 1500)).toBe(6) // 8.0/s vs 9.76/s = 0.82 → real loss, revert
+      expect(h.c.getState()).toBe('hold')
+      expect(reasons(h)).toEqual(['hold', 'step-down', 'step-down', 'step-down', 'revert'])
+    })
+
+    it('rejects the first down-step immediately on an RTT-bound link', () => {
+      const h = makeController({ profile: { learnedLimit: 8, baselineLatencyMs: 100 } })
+      feed(h.c, T.validateAfterCompletions, 100)
+      closeWindow(h, 1200, { count: 4 }) // baseline 10/s at 8
+      closeWindow(h, 1200) // plateau → 7, climb-down
+      // RTT-bound: goodput ∝ limit, so 7 connections do 7/8 of the work.
+      expect(closeWindow(h, 1371)).toBe(8) // 8.75/s vs 10/s = 0.875 < 0.98 → revert
+      expect(h.c.getState()).toBe('hold')
+    })
+  })
+
+  describe('hold', () => {
+    /** Drive a controller into HOLD at limit 8 with best goodput 10/s. */
+    const settleAtHold = (): Harness => {
+      const h = makeController({ profile: { learnedLimit: 8, baselineLatencyMs: 100 } })
+      feed(h.c, T.validateAfterCompletions, 100)
+      closeWindow(h, 1200, { count: 4 }) // baseline 10/s
+      closeWindow(h, 1200) // plateau → 7, climb-down
+      closeWindow(h, 1371) // RTT-bound loss → revert to 8, HOLD, best = 10/s
+      h.ticks.length = 0
+      return h
+    }
+
+    it('steps down only after two consecutive degraded windows', () => {
+      const h = settleAtHold()
+      closeWindow(h, 1412) // 8.5/s < 0.9 × (10 × 0.98 decay) = 8.82 → strike one
+      expect(h.c.getLimit()).toBe(8)
+      expect(h.ticks[0].reason).toBe('hold')
+      closeWindow(h, 1412) // 8.5/s < 0.9 × 9.604 = 8.64 → strike two
+      expect(h.c.getLimit()).toBe(7)
+      expect(h.ticks[1].reason).toBe('step-down')
+    })
+
+    it('a single degraded window between healthy ones never moves the limit', () => {
+      const h = settleAtHold()
+      closeWindow(h, 1412) // degraded once
+      closeWindow(h, 1200) // healthy again → streak resets
+      closeWindow(h, 1412) // degraded once more — still only one in a row
+      expect(h.c.getLimit()).toBe(8)
+      expect(reasons(h)).not.toContain('step-down')
+    })
+
+    it('decays the best-goodput reference so a stale lucky window cannot force step-downs', () => {
+      const h = settleAtHold()
+      // 15 quiet windows at 9.3/s (93% of the old best): decay floors the
+      // reference at the current level, so nothing ever looks degraded.
+      for (let i = 0; i < 15; i++) closeWindow(h, 1290)
+      expect(reasons(h)).not.toContain('step-down')
+      expect(h.c.getLimit()).toBeGreaterThanOrEqual(8) // probes may nudge it up
+    })
+
+    it('probes upward after reprobeAfterWindows and keeps the gain when real', () => {
+      const h = settleAtHold()
+      for (let i = 0; i < T.reprobeAfterWindows - 1; i++) closeWindow(h, 1200)
+      expect(reasons(h)).not.toContain('probe-up')
+      closeWindow(h, 1200) // reprobe timer fires
+      expect(reasons(h)).toContain('probe-up')
+      expect(h.c.getLimit()).toBe(9)
+      closeWindow(h, 1000) // 12/s vs 10/s = 1.2 ≥ gainEpsilon → accepted, keep climbing
+      expect(h.c.getLimit()).toBe(10)
+      expect(h.c.getState()).toBe('climb-up')
+    })
+
+    it('rejects a probe that bought nothing', () => {
+      const h = settleAtHold()
+      for (let i = 0; i < T.reprobeAfterWindows; i++) closeWindow(h, 1200)
+      expect(h.c.getLimit()).toBe(9) // probing
+      closeWindow(h, 1200) // 10/s vs 10/s → no gain
+      expect(h.c.getLimit()).toBe(8)
+      expect(reasons(h)).toContain('probe-reject')
+      expect(h.c.getState()).toBe('hold')
+    })
+  })
+
+  describe('error handling (unchanged AIMD semantics)', () => {
+    it('halves the limit immediately on congestion, from any state', () => {
+      const h = makeController({ profile: { learnedLimit: 16, baselineLatencyMs: 100 } })
+      const immediate = h.c.record('congested')
+      expect(immediate).toBe(8) // 16 × 0.5, applied now, not at the next tick
+      expect(h.c.getLimit()).toBe(8)
+      expect(h.c.getState()).toBe('hold')
+    })
+
+    it('soft-decreases at the tick when the window saw retryable errors', () => {
+      const h = makeController({ profile: { learnedLimit: 10, baselineLatencyMs: 100 } })
+      feed(h.c, T.windowCompletions - 1, 100)
+      h.c.record('retryable')
+      const ticked = h.c.maybeTick(h.clock.advance(1200))
+      expect(ticked).toBe(7) // 10 × 0.7
+      expect(h.ticks.at(-1)?.reason).toBe('soft-down')
+      // The next clean window only re-establishes a baseline — no instant re-climb.
+      expect(closeWindow(h, 1200)).toBe(null)
+      expect(h.ticks.at(-1)?.reason).toBe('hold')
+    })
+  })
+
+  describe('ETag 304 comparability guard', () => {
+    it('skips the decision when the revalidated share shifts, then resumes', () => {
+      const h = makeController({})
+      closeWindow(h, 1200) // blind double → 8, ratio 0
+      // Warm-cache burst: 10/12 are 304s — fast, but not comparable to window 1.
+      closeWindow(h, 300, { revalidatedCount: 10 })
+      expect(h.c.getLimit()).toBe(8) // decision skipped
+      expect(h.ticks.at(-1)?.reason).toBe('hold')
+      // Same mix again: comparable → gating resumes against the rolled baseline.
+      closeWindow(h, 200, { revalidatedCount: 10 }) // 60/s vs 40/s = 1.5× → double
+      expect(h.c.getLimit()).toBe(16)
+    })
+  })
+
+  describe('freeze (run tail)', () => {
+    it('stops making decisions once frozen', () => {
+      const h = makeController({})
+      closeWindow(h, 1200) // → 8
+      h.c.freeze()
+      const ticked = closeWindow(h, 300) // would have doubled
+      expect(ticked).toBe(null)
+      expect(h.c.getLimit()).toBe(8)
+      expect(h.ticks).toHaveLength(1)
+    })
+  })
+
+  describe('settled profile', () => {
+    it('returns the settled limit once HOLD was reached', () => {
+      const h = makeController({ profile: { learnedLimit: 8, baselineLatencyMs: 100 } })
+      feed(h.c, T.validateAfterCompletions, 100)
+      closeWindow(h, 1200, { count: 4 })
+      closeWindow(h, 1200) // → 7, climb-down
+      closeWindow(h, 1371) // revert → 8, HOLD  (36 completions total)
+      h.c.freeze()
+      const profile = h.c.getSettledProfile(5_000_000)
+      expect(profile).not.toBeNull()
+      expect(profile?.schemaVersion).toBe(1)
+      expect(profile?.learnedLimit).toBe(8)
+      expect(profile?.baselineLatencyMs).toBe(100)
+      expect(profile?.sampleCount).toBeGreaterThanOrEqual(30)
+      expect(profile?.updatedAt).toBe(new Date(5_000_000).toISOString())
+    })
+
+    it('returns null when HOLD was never reached', () => {
+      const h = makeController({})
+      closeWindow(h, 1200) // still slow-starting
+      h.c.freeze()
+      expect(h.c.getSettledProfile(5_000_000)).toBeNull()
+    })
+
+    it('returns null when congestion hit in the final windows', () => {
+      const h = makeController({ profile: { learnedLimit: 8, baselineLatencyMs: 100 } })
+      feed(h.c, T.validateAfterCompletions, 100)
+      closeWindow(h, 1200, { count: 4 })
+      closeWindow(h, 1200)
+      closeWindow(h, 1371) // HOLD at 8
+      h.c.record('congested') // hard-down in the current window
+      closeWindow(h, 1200, { count: T.windowCompletions - 1 })
+      h.c.freeze()
+      expect(h.c.getSettledProfile(5_000_000)).toBeNull()
+    })
+  })
+
+  describe('profile validation at run start', () => {
+    it('resets to coldStart when the network regime is drastically worse', () => {
+      const h = makeController({ profile: { learnedLimit: 16, baselineLatencyMs: 120 } })
+      expect(h.c.getLimit()).toBe(16)
+      const immediate = feed(h.c, T.validateAfterCompletions, 900)
+      // 900ms EWMA > max(3 × 120, 500) → the profile is a lie here; restart low.
+      expect(immediate).toBe(T.coldStart)
+      expect(h.c.getLimit()).toBe(T.coldStart)
+      expect(h.c.getState()).toBe('slow-start')
+      expect(reasons(h)).toContain('regime-reset')
+    })
+
+    it('keeps the learned limit when the regime matches', () => {
+      const h = makeController({ profile: { learnedLimit: 16, baselineLatencyMs: 120 } })
+      feed(h.c, T.validateAfterCompletions, 110)
+      expect(h.c.getLimit()).toBe(16)
+      expect(reasons(h)).not.toContain('regime-reset')
+    })
+
+    it('keeps the learned limit when the network got faster (doubling handles it)', () => {
+      const h = makeController({ profile: { learnedLimit: 8, baselineLatencyMs: 400 } })
+      feed(h.c, T.validateAfterCompletions, 20)
+      expect(h.c.getLimit()).toBe(8)
+      expect(reasons(h)).not.toContain('regime-reset')
+    })
+
+    it('clamps an out-of-range learned limit into [floor, ceil]', () => {
+      const h = makeController({ profile: { learnedLimit: 99, baselineLatencyMs: 100 } })
+      expect(h.c.getLimit()).toBe(T.ceil)
+    })
+  })
+
+  describe('instrumentation', () => {
+    it('emits goodput, state, and revalidated ratio on every tick', () => {
+      const h = makeController({})
+      closeWindow(h, 1200, { revalidatedCount: 3 })
+      const tick = h.ticks[0]
+      expect(tick.goodputRps).toBeCloseTo(10, 1)
+      expect(tick.state).toBe('slow-start')
+      expect(tick.revalidatedRatio).toBeCloseTo(0.25, 2)
+      expect(tick.limit).toBe(8)
+      expect(tick.atMs).toBe(START_AT + 1200)
+    })
+  })
+})

--- a/test/unit/shared/math.test.ts
+++ b/test/unit/shared/math.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { clamp, Ewma, round2, roundTo } from '../../../src/shared/math'
+
+describe('clamp', () => {
+  it('returns the value when it is inside the range', () => {
+    expect(clamp(5, 1, 10)).toBe(5)
+  })
+
+  it('clamps below to the lower bound and above to the upper bound', () => {
+    expect(clamp(-3, 1, 10)).toBe(1)
+    expect(clamp(42, 1, 10)).toBe(10)
+  })
+
+  it('collapses to the single point when lo === hi', () => {
+    expect(clamp(7, 4, 4)).toBe(4)
+  })
+})
+
+describe('roundTo / round2', () => {
+  it('rounds to the requested number of decimal places', () => {
+    expect(roundTo(1.23456, 3)).toBe(1.235)
+    expect(roundTo(1.5, 0)).toBe(2)
+  })
+
+  it('round2 rounds to two decimal places', () => {
+    expect(round2(1.98765)).toBe(1.99)
+    expect(round2(2.567)).toBe(2.57)
+  })
+})
+
+describe('Ewma', () => {
+  it('is zero-valued with zero samples before the first update', () => {
+    const ewma = new Ewma(0.3)
+    expect(ewma.value).toBe(0)
+    expect(ewma.count).toBe(0)
+  })
+
+  it('seeds from the first sample instead of averaging against zero', () => {
+    const ewma = new Ewma(0.3)
+    ewma.update(100)
+    expect(ewma.value).toBe(100)
+    expect(ewma.count).toBe(1)
+  })
+
+  it('blends later samples with the configured alpha', () => {
+    const ewma = new Ewma(0.3)
+    ewma.update(100)
+    ewma.update(200)
+    // 0.3 * 200 + 0.7 * 100
+    expect(ewma.value).toBeCloseTo(130)
+    expect(ewma.count).toBe(2)
+  })
+})

--- a/test/unit/shared/registry/npm-registry.test.ts
+++ b/test/unit/shared/registry/npm-registry.test.ts
@@ -513,6 +513,170 @@ describe('npm-registry', () => {
     })
   })
 
+  describe('hill-climb wiring', () => {
+    const names = (n: number) => Array.from({ length: n }, (_, i) => `pkg-${i + 1}`)
+
+    /**
+     * A bandwidth-bound pipe: responses are serialized through a promise chain
+     * at a fixed cost each, so total goodput is flat no matter how many
+     * requests are in flight — exactly what a narrow link looks like.
+     */
+    const withBandwidthBoundPipe = (costMs: number) => {
+      let chain = Promise.resolve()
+      requestMock.mockImplementation(async () => {
+        const my = chain.then(() => new Promise<void>((r) => setTimeout(r, costMs)))
+        chain = my
+        await my
+        return makeOkBody({ versions: { '1.0.0': {} } })
+      })
+    }
+
+    it('adapts DOWN on a bandwidth-bound link without any error signal', async () => {
+      withBandwidthBoundPipe(8)
+      const ticks: ControlTick[] = []
+
+      const result = await fetchPackageVersions(names(100), {
+        onControlTick: (t) => ticks.push(t),
+      })
+
+      expect(result.size).toBe(100)
+      // Passive down-adaptation: the flat pipe must produce at least one
+      // goodput-driven down decision — with zero 429s or network errors.
+      expect(ticks.some((t) => t.reason === 'revert' || t.reason === 'step-down')).toBe(true)
+      expect(ticks.some((t) => t.reason === 'hard-down' || t.reason === 'soft-down')).toBe(false)
+      expect(ticks.at(-1)!.limit).toBeLessThanOrEqual(8)
+    })
+
+    it('reaches the ceiling by doubling on a fast link', async () => {
+      let inFlight = 0
+      let peak = 0
+      requestMock.mockImplementation(async () => {
+        inFlight++
+        peak = Math.max(peak, inFlight)
+        await new Promise((r) => setTimeout(r, 5))
+        inFlight--
+        return makeOkBody({ versions: { '1.0.0': {} } })
+      })
+      const ticks: ControlTick[] = []
+
+      await fetchPackageVersions(names(120), {
+        onControlTick: (t) => ticks.push(t),
+      })
+
+      expect(ticks.some((t) => t.reason === 'double')).toBe(true)
+      expect(ticks.some((t) => t.limit === 24)).toBe(true)
+      expect(peak).toBeLessThanOrEqual(24)
+    })
+
+    it('concurrency option pins the limit and disables the controller', async () => {
+      let inFlight = 0
+      let peak = 0
+      requestMock.mockImplementation(async () => {
+        inFlight++
+        peak = Math.max(peak, inFlight)
+        await new Promise((r) => setTimeout(r, 5))
+        inFlight--
+        return makeOkBody({ versions: { '1.0.0': {} } })
+      })
+      const ticks: ControlTick[] = []
+
+      await fetchPackageVersions(names(40), {
+        concurrency: 5,
+        onControlTick: (t) => ticks.push(t),
+      })
+
+      expect(peak).toBeLessThanOrEqual(5)
+      expect(ticks).toHaveLength(0)
+    })
+
+    it('starts from the injected network profile when the regime matches', async () => {
+      requestMock.mockResolvedValue(makeOkBody({ versions: { '1.0.0': {} } }))
+      const ticks: ControlTick[] = []
+
+      await fetchPackageVersions(names(60), {
+        networkProfile: {
+          schemaVersion: 1,
+          learnedLimit: 8,
+          baselineLatencyMs: 100,
+          baselineGoodputRps: 10,
+          sampleCount: 100,
+          updatedAt: new Date(0).toISOString(),
+        },
+        onControlTick: (t) => ticks.push(t),
+      })
+
+      // The first window runs (and reports) at the learned limit.
+      expect(ticks[0].limit).toBeGreaterThanOrEqual(8)
+    })
+
+    it('uses the learned limit as the fixed start for runs too small to control', async () => {
+      let inFlight = 0
+      let peak = 0
+      requestMock.mockImplementation(async () => {
+        inFlight++
+        peak = Math.max(peak, inFlight)
+        await new Promise((r) => setTimeout(r, 5))
+        inFlight--
+        return makeOkBody({ versions: { '1.0.0': {} } })
+      })
+      const ticks: ControlTick[] = []
+
+      await fetchPackageVersions(names(20), {
+        networkProfile: {
+          schemaVersion: 1,
+          learnedLimit: 5,
+          baselineLatencyMs: 100,
+          baselineGoodputRps: 10,
+          sampleCount: 100,
+          updatedAt: new Date(0).toISOString(),
+        },
+        onControlTick: (t) => ticks.push(t),
+      })
+
+      expect(ticks).toHaveLength(0) // too small for the controller…
+      expect(peak).toBeLessThanOrEqual(5) // …but the learned limit still caps the fixed start
+    })
+
+    it('emits a settled profile via onNetworkProfile once the run held', async () => {
+      withBandwidthBoundPipe(8)
+      const profiles: unknown[] = []
+
+      await fetchPackageVersions(names(100), {
+        onNetworkProfile: (p) => profiles.push(p),
+      })
+
+      expect(profiles).toHaveLength(1)
+      const profile = profiles[0] as { schemaVersion: number; learnedLimit: number }
+      expect(profile.schemaVersion).toBe(1)
+      expect(profile.learnedLimit).toBeLessThanOrEqual(8)
+    })
+
+    it('does not emit a profile for runs too small to control', async () => {
+      requestMock.mockResolvedValue(makeOkBody({ versions: { '1.0.0': {} } }))
+      const profiles: unknown[] = []
+
+      await fetchPackageVersions(names(12), {
+        onNetworkProfile: (p) => profiles.push(p),
+      })
+
+      expect(profiles).toHaveLength(0)
+    })
+
+    it('controllerMode aimd selects the control arm (smart start at the ceiling)', async () => {
+      requestMock.mockResolvedValue(makeOkBody({ versions: { '1.0.0': {} } }))
+      const ticks: ControlTick[] = []
+
+      await fetchPackageVersions(names(120), {
+        controllerMode: 'aimd',
+        onControlTick: (t) => ticks.push(t),
+      })
+
+      expect(ticks.length).toBeGreaterThan(0)
+      expect(ticks[0].limit).toBe(24) // AIMD smart-starts at the ceiling
+      expect(ticks.some((t) => t.reason === 'double')).toBe(false)
+    })
+  })
+
   describe('ETag conditional caching', () => {
     // Isolated root per test: never wipe (or race parallel test files on) the
     // user's real persistent cache directory.

--- a/test/unit/shared/registry/npm-registry.test.ts
+++ b/test/unit/shared/registry/npm-registry.test.ts
@@ -665,6 +665,38 @@ describe('npm-registry', () => {
       expect(profiles).toHaveLength(0)
     })
 
+    it('survives a mid-run blackout: completes, backs off, reports partial results', async () => {
+      // Simulated disconnect/reconnect: calls 41-100 all fail with a transient
+      // network error (every retry attempt included), then the link is back.
+      let calls = 0
+      requestMock.mockImplementation(async () => {
+        calls++
+        if (calls > 40 && calls <= 100) {
+          const error = new Error('socket hang up')
+          error.name = 'AbortError'
+          throw error
+        }
+        await new Promise((r) => setTimeout(r, 3))
+        return makeOkBody({ versions: { '1.0.0': {} } })
+      })
+      const ticks: ControlTick[] = []
+
+      const result = await fetchPackageVersions(names(80), {
+        onControlTick: (t) => ticks.push(t),
+      })
+
+      // Every package gets an answer — the run never hangs or throws.
+      expect(result.size).toBe(80)
+      const unavailable = [...result.values()].filter((v) => v.latestVersion === 'unknown')
+      // A partial outage, visibly partial: some packages exhausted their
+      // retries during the blackout, the rest resolved after the reconnect.
+      expect(unavailable.length).toBeGreaterThan(0)
+      expect(unavailable.length).toBeLessThan(80)
+      // The controller backed off on the transient errors — no 429 needed.
+      expect(ticks.some((t) => t.reason === 'soft-down')).toBe(true)
+      expect(ticks.some((t) => t.reason === 'hard-down')).toBe(false)
+    })
+
     it('controllerMode aimd selects the control arm (smart start at the ceiling)', async () => {
       requestMock.mockResolvedValue(makeOkBody({ versions: { '1.0.0': {} } }))
       const ticks: ControlTick[] = []

--- a/test/unit/shared/registry/npm-registry.test.ts
+++ b/test/unit/shared/registry/npm-registry.test.ts
@@ -516,6 +516,27 @@ describe('npm-registry', () => {
   describe('hill-climb wiring', () => {
     const names = (n: number) => Array.from({ length: n }, (_, i) => `pkg-${i + 1}`)
 
+    // The whole block runs on a virtual clock: mock latencies are fake-timer
+    // milliseconds, so window goodput — and therefore every controller
+    // decision — is exact and load-independent. Real timers made these tests
+    // flake under coverage instrumentation.
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    /** Start the fetch, drain the virtual clock, return the result. */
+    const runFetch = async (
+      packageNames: string[],
+      options: Parameters<typeof fetchPackageVersions>[1]
+    ) => {
+      const done = fetchPackageVersions(packageNames, options)
+      await vi.runAllTimersAsync()
+      return done
+    }
+
     /**
      * A bandwidth-bound pipe: responses are serialized through a promise chain
      * at a fixed cost each, so total goodput is flat no matter how many
@@ -531,11 +552,25 @@ describe('npm-registry', () => {
       })
     }
 
+    /** A fast, wide link: fixed per-response latency, unlimited parallelism. */
+    const withFastLink = (latencyMs: number) => {
+      let inFlight = 0
+      let peak = 0
+      requestMock.mockImplementation(async () => {
+        inFlight++
+        peak = Math.max(peak, inFlight)
+        await new Promise((r) => setTimeout(r, latencyMs))
+        inFlight--
+        return makeOkBody({ versions: { '1.0.0': {} } })
+      })
+      return () => peak
+    }
+
     it('adapts DOWN on a bandwidth-bound link without any error signal', async () => {
       withBandwidthBoundPipe(8)
       const ticks: ControlTick[] = []
 
-      const result = await fetchPackageVersions(names(100), {
+      const result = await runFetch(names(100), {
         onControlTick: (t) => ticks.push(t),
       })
 
@@ -548,55 +583,38 @@ describe('npm-registry', () => {
     })
 
     it('reaches the ceiling by doubling on a fast link', async () => {
-      let inFlight = 0
-      let peak = 0
-      // 20ms per response: large against scheduler noise, so window-over-window
-      // goodput gains stay well above the doubling gate even under a loaded
-      // test runner (real timers make this an inherently timing-based test).
-      requestMock.mockImplementation(async () => {
-        inFlight++
-        peak = Math.max(peak, inFlight)
-        await new Promise((r) => setTimeout(r, 20))
-        inFlight--
-        return makeOkBody({ versions: { '1.0.0': {} } })
-      })
+      const getPeak = withFastLink(20)
       const ticks: ControlTick[] = []
 
-      await fetchPackageVersions(names(120), {
+      await runFetch(names(120), {
         onControlTick: (t) => ticks.push(t),
       })
 
+      // Virtual clock: 12-completion windows at limits 4/8/16 take exactly
+      // 60/40/20 fake-ms → gains 1.5 and 2.0 clear the doubling gate every time.
       expect(ticks.filter((t) => t.reason === 'double').length).toBeGreaterThanOrEqual(2)
-      expect(Math.max(...ticks.map((t) => t.limit))).toBeGreaterThanOrEqual(16)
-      expect(peak).toBeLessThanOrEqual(24)
+      expect(Math.max(...ticks.map((t) => t.limit))).toBe(24)
+      expect(getPeak()).toBeLessThanOrEqual(24)
     })
 
     it('concurrency option pins the limit and disables the controller', async () => {
-      let inFlight = 0
-      let peak = 0
-      requestMock.mockImplementation(async () => {
-        inFlight++
-        peak = Math.max(peak, inFlight)
-        await new Promise((r) => setTimeout(r, 5))
-        inFlight--
-        return makeOkBody({ versions: { '1.0.0': {} } })
-      })
+      const getPeak = withFastLink(5)
       const ticks: ControlTick[] = []
 
-      await fetchPackageVersions(names(40), {
+      await runFetch(names(40), {
         concurrency: 5,
         onControlTick: (t) => ticks.push(t),
       })
 
-      expect(peak).toBeLessThanOrEqual(5)
+      expect(getPeak()).toBeLessThanOrEqual(5)
       expect(ticks).toHaveLength(0)
     })
 
     it('starts from the injected network profile when the regime matches', async () => {
-      requestMock.mockResolvedValue(makeOkBody({ versions: { '1.0.0': {} } }))
+      withFastLink(5)
       const ticks: ControlTick[] = []
 
-      await fetchPackageVersions(names(60), {
+      await runFetch(names(60), {
         networkProfile: {
           schemaVersion: 1,
           learnedLimit: 8,
@@ -613,18 +631,10 @@ describe('npm-registry', () => {
     })
 
     it('uses the learned limit as the fixed start for runs too small to control', async () => {
-      let inFlight = 0
-      let peak = 0
-      requestMock.mockImplementation(async () => {
-        inFlight++
-        peak = Math.max(peak, inFlight)
-        await new Promise((r) => setTimeout(r, 5))
-        inFlight--
-        return makeOkBody({ versions: { '1.0.0': {} } })
-      })
+      const getPeak = withFastLink(5)
       const ticks: ControlTick[] = []
 
-      await fetchPackageVersions(names(20), {
+      await runFetch(names(20), {
         networkProfile: {
           schemaVersion: 1,
           learnedLimit: 5,
@@ -637,14 +647,14 @@ describe('npm-registry', () => {
       })
 
       expect(ticks).toHaveLength(0) // too small for the controller…
-      expect(peak).toBeLessThanOrEqual(5) // …but the learned limit still caps the fixed start
+      expect(getPeak()).toBeLessThanOrEqual(5) // …but the learned limit still caps the fixed start
     })
 
     it('emits a settled profile via onNetworkProfile once the run held', async () => {
       withBandwidthBoundPipe(8)
       const profiles: unknown[] = []
 
-      await fetchPackageVersions(names(100), {
+      await runFetch(names(100), {
         onNetworkProfile: (p) => profiles.push(p),
       })
 
@@ -658,7 +668,7 @@ describe('npm-registry', () => {
       requestMock.mockResolvedValue(makeOkBody({ versions: { '1.0.0': {} } }))
       const profiles: unknown[] = []
 
-      await fetchPackageVersions(names(12), {
+      await runFetch(names(12), {
         onNetworkProfile: (p) => profiles.push(p),
       })
 
@@ -681,7 +691,7 @@ describe('npm-registry', () => {
       })
       const ticks: ControlTick[] = []
 
-      const result = await fetchPackageVersions(names(80), {
+      const result = await runFetch(names(80), {
         onControlTick: (t) => ticks.push(t),
       })
 
@@ -701,7 +711,7 @@ describe('npm-registry', () => {
       requestMock.mockResolvedValue(makeOkBody({ versions: { '1.0.0': {} } }))
       const ticks: ControlTick[] = []
 
-      await fetchPackageVersions(names(120), {
+      await runFetch(names(120), {
         controllerMode: 'aimd',
         onControlTick: (t) => ticks.push(t),
       })
@@ -709,6 +719,54 @@ describe('npm-registry', () => {
       expect(ticks.length).toBeGreaterThan(0)
       expect(ticks[0].limit).toBe(24) // AIMD smart-starts at the ceiling
       expect(ticks.some((t) => t.reason === 'double')).toBe(false)
+    })
+
+    it('applies a failed profile validation to the semaphore immediately', async () => {
+      // 600 fake-ms per response against a 10ms baseline: the regime check
+      // fails on the 8th success and the returned cold-start limit must reach
+      // the semaphore through the success path of the observer.
+      const getPeak = withFastLink(600)
+      const ticks: ControlTick[] = []
+
+      const result = await runFetch(names(60), {
+        networkProfile: {
+          schemaVersion: 1,
+          learnedLimit: 24,
+          baselineLatencyMs: 10,
+          baselineGoodputRps: 100,
+          sampleCount: 100,
+          updatedAt: new Date(0).toISOString(),
+        },
+        onControlTick: (t) => ticks.push(t),
+      })
+
+      expect(result.size).toBe(60)
+      expect(ticks.some((t) => t.reason === 'regime-reset')).toBe(true)
+      expect(getPeak()).toBeLessThanOrEqual(24)
+    })
+
+    it('emits no profile when congestion never lets the run settle', async () => {
+      // A 429 storm through the whole run: the controller keeps hard-halving,
+      // so whatever limit it ends on is a back-off artifact, not a profile.
+      let calls = 0
+      requestMock.mockImplementation(async () => {
+        calls++
+        if (calls % 4 === 0) {
+          return { statusCode: 429, body: '', headers: { 'retry-after': '0' } }
+        }
+        await new Promise((r) => setTimeout(r, 3))
+        return makeOkBody({ versions: { '1.0.0': {} } })
+      })
+      const profiles: unknown[] = []
+      const ticks: ControlTick[] = []
+
+      await runFetch(names(60), {
+        onNetworkProfile: (p) => profiles.push(p),
+        onControlTick: (t) => ticks.push(t),
+      })
+
+      expect(ticks.some((t) => t.reason === 'hard-down')).toBe(true)
+      expect(profiles).toHaveLength(0)
     })
   })
 

--- a/test/unit/shared/registry/npm-registry.test.ts
+++ b/test/unit/shared/registry/npm-registry.test.ts
@@ -550,10 +550,13 @@ describe('npm-registry', () => {
     it('reaches the ceiling by doubling on a fast link', async () => {
       let inFlight = 0
       let peak = 0
+      // 20ms per response: large against scheduler noise, so window-over-window
+      // goodput gains stay well above the doubling gate even under a loaded
+      // test runner (real timers make this an inherently timing-based test).
       requestMock.mockImplementation(async () => {
         inFlight++
         peak = Math.max(peak, inFlight)
-        await new Promise((r) => setTimeout(r, 5))
+        await new Promise((r) => setTimeout(r, 20))
         inFlight--
         return makeOkBody({ versions: { '1.0.0': {} } })
       })
@@ -563,8 +566,8 @@ describe('npm-registry', () => {
         onControlTick: (t) => ticks.push(t),
       })
 
-      expect(ticks.some((t) => t.reason === 'double')).toBe(true)
-      expect(ticks.some((t) => t.limit === 24)).toBe(true)
+      expect(ticks.filter((t) => t.reason === 'double').length).toBeGreaterThanOrEqual(2)
+      expect(Math.max(...ticks.map((t) => t.limit))).toBeGreaterThanOrEqual(16)
       expect(peak).toBeLessThanOrEqual(24)
     })
 


### PR DESCRIPTION
## Problem

On a slow but healthy connection, "Loading packages…" crawls. The AIMD controller backs off only on real error signals (429/503), so a narrow pipe gets split across the full ceiling of 24 sockets — correct for congestion, blind to low bandwidth.

## Solution

A slow-start + hill-climb concurrency controller (`src/shared/http/hill-climb-controller.ts`) that measures **goodput** — completions per second over 12-completion windows of requests we make anyway — and climbs the concurrency hill toward the knee of the curve:

- **slow-start**: double while a doubling still buys ≥25% goodput
- **climb-up / climb-down**: ±1 per window with asymmetric hysteresis (+5% to move up, sustained −10% to move down)
- **hold**: sit at the knee; probe +1 occasionally to catch recovery
- **validating**: a persisted profile is confirmed against live latency before being trusted

Design constraints that came out of the earlier AIMD oscillation failure:

- Per-request latency **never** drives a decision. It is used exactly once: the start-of-run regime check against the persisted baseline, double-gated (3× **and** ≥500 ms) so CDN jitter cannot clear it. The check is symmetric — a stale slow-link profile cannot drag a now-fast link.
- Windows with a very different ETag-304 share are not compared (a 304 is header-sized and fast on any link), and the persisted latency baseline is full-fetch-only, so warm-cache runs can neither fake a regime change nor poison the next run's check.
- Error semantics are inherited from AIMD unchanged: 429/503 hard-halves immediately; retryable errors soft-decrease at the tick.
- Non-monotonic clock windows and half-timed windows after a hard-down are discarded, never mis-measured.

## Also in this PR

- **Learned `NetworkProfile`** persisted in user config (atomic write-then-rename, `schemaVersion`, 7-day expiry with future-clock-skew tolerance). A starting hypothesis, never a cap.
- **`--concurrency` flag and `.inuprc` `concurrency` field** — pin escape hatch that disables adaptation (flag > `.inuprc`), validated at every boundary including a final clamp at the registry.
- **Slow-connection hint** in the loading line + hill-climb rows in the perf modal.
- **Experiment kit**: `scripts/hill-climb-experiment.sh`, `scripts/analyze-hill-climb.py`, `docs/rnd/hill-climb-concurrency.md`.
- **Structural refactor** (795f61a): controller contract types extracted to `controller-contract.ts` (removes a manually-synced duplicate in `features/debug/types.ts`), shared `math.ts` (`clamp`/`roundTo`/`round2`/`Ewma` replace three EWMA copies and five clamps), `sanitizeTuning` for experiment overrides, `AdaptiveController implements ConcurrencyController`.

`AdaptiveController` stays as the A/B control arm (`INUP_CONTROLLER=aimd`).

## Testing

- 1224 tests; the 100/100/100/100 coverage ratchet holds.
- Controller unit suite covers unhappy paths: disconnect-to-floor, reconnect recovery, congestion during probe / at floor / after freeze, latency-spike no-op, zero-elapsed windows, corrupt baselines, all-304 runs.
- Integration tests run the full registry wiring on fake timers (deterministic network simulation) plus live-registry smoke tests.
- Three adversarial review passes; all findings fixed (see "Review hardening" in the doc).

## Before merging

The throttled A/B experiment is still pending — it needs system-level throttling (Network Link Conditioner / dummynet), which has to be run manually. Success criteria and the runbook are in `docs/rnd/hill-climb-concurrency.md`. Toggles: `INUP_CONTROLLER=aimd|hillclimb`, `INUP_ADAPTIVE=0`, `INUP_NET_PROFILE=0`.
