### PR TITLE
feat(config): ignoreMajor — suppress major updates per package

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ Unlike `--json` and `--check`, **`--apply` writes**: it bumps `package.json` and
 manager's install to update the lockfile. By default (`--target minor`) it only applies **in-range**
 updates and leaves majors for you to review; `--target patch` stays within the current
 `major.minor` line (patch bumps only); `--target latest` includes majors. It honors `.inuprc`
-(`ignore`, `exclude`, `scanDirs`) exactly as the report does — a package the config excludes is
-never written. With `--apply --json`, the install output goes to stderr so stdout stays pure JSON.
+(`ignore`, `ignoreMajor`, `exclude`, `scanDirs`) exactly as the report does — a package the config
+excludes is never written, and an `ignoreMajor` match is held to its in-range bump even under
+`--target latest`. With `--apply --json`, the install output goes to stderr so stdout stays pure JSON.
 
 **pnpm catalogs work in every mode.** Dependencies declared as `catalog:` / `catalog:<name>` are
 resolved from `pnpm-workspace.yaml`; `--apply` writes the new range back into that file (comments
@@ -243,7 +244,7 @@ your name/email as repo secrets (Settings → Secrets and variables → Actions)
 Outputs: `outdated`, `vulnerable`, `pull-request-number`.
 
 > `@v1` floats to the latest `1.x` release; pin to `@v1.6.2` or a SHA for reproducible runs. inup
-> honors your `.inuprc` (`ignore`, `exclude`, `scanDirs`).
+> honors your `.inuprc` (`ignore`, `ignoreMajor`, `exclude`, `scanDirs`).
 
 </details>
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -140,6 +140,7 @@ export async function runCli(options: CliOptions): Promise<void> {
     scanDirs: projectConfig.scanDirs,
     maxDepth,
     ignorePackages,
+    ignoreMajorPackages: projectConfig.ignoreMajor,
     packageManager,
     showPeerDependencyVulnerabilities: projectConfig.showPeerDependencyVulnerabilities ?? false,
     showOptionalDependencyVulnerabilities:

--- a/src/features/headless/headless-runner.ts
+++ b/src/features/headless/headless-runner.ts
@@ -148,6 +148,11 @@ export class HeadlessRunner {
   /** Resolve the version a package should be bumped to under the given policy, or null to skip. */
   private resolveTargetVersion(pkg: PackageInfo, target: ApplyTarget): string | null {
     if (target === 'latest') {
+      // ignoreMajor holds matched packages to their in-range bump even under
+      // --target latest; without a range update there is nothing to write.
+      if (pkg.majorIgnored) {
+        return pkg.hasRangeUpdate ? pkg.rangeVersion || null : null
+      }
       return pkg.latestVersion || null
     }
     if (target === 'patch') {

--- a/src/features/headless/report.ts
+++ b/src/features/headless/report.ts
@@ -28,6 +28,7 @@ export function buildHeadlessReport(
         packageJsonPath: pkg.packageJsonPath,
         hasMajorUpdate: pkg.hasMajorUpdate,
       }
+      if (pkg.majorIgnored) entry.majorIgnored = true
       if (pkg.catalog) entry.catalog = pkg.catalog
       if (pkg.deprecated) entry.deprecated = pkg.deprecated
       if (pkg.enginesNode) entry.enginesNode = pkg.enginesNode
@@ -50,7 +51,10 @@ export function renderPlainReport(
   const lines = outdated.map((pkg) => {
     const major = pkg.hasMajorUpdate ? ' (major)' : ''
     const deprecated = pkg.deprecated ? '  [deprecated]' : ''
-    return `${pkg.name}  ${pkg.currentVersion} → ${pkg.latestVersion}  [${pkg.type}]${major}${vulnMarker(vulnerabilities.get(pkg))}${deprecated}`
+    // With ignoreMajor in effect the actionable target is the in-range bump,
+    // so the arrow points there instead of at the suppressed major.
+    const displayTarget = pkg.majorIgnored ? pkg.rangeVersion : pkg.latestVersion
+    return `${pkg.name}  ${pkg.currentVersion} → ${displayTarget}  [${pkg.type}]${major}${vulnMarker(vulnerabilities.get(pkg))}${deprecated}`
   })
 
   const fileCount = new Set(outdated.map((pkg) => pkg.packageJsonPath)).size

--- a/src/features/headless/types.ts
+++ b/src/features/headless/types.ts
@@ -23,6 +23,7 @@ export interface HeadlessReportEntry {
   packageJsonPath: string // pnpm-workspace.yaml for catalog entries
   catalog?: string // pnpm catalog the range is defined in ('default' or a named catalog)
   hasMajorUpdate: boolean
+  majorIgnored?: boolean // Major update exists but .inuprc ignoreMajor suppresses it (hasMajorUpdate is false)
   deprecated?: string // npm deprecation message for the latest version, if any
   enginesNode?: string // declared engines.node range for the latest version, if any
   vulnerability?: HeadlessVulnerability // Advisories on the current version + whether upgrading clears them

--- a/src/features/upgrade/package-detector.ts
+++ b/src/features/upgrade/package-detector.ts
@@ -45,6 +45,7 @@ export class PackageDetector {
   private excludePatterns: string[]
   private scanDirs: string[]
   private ignorePackages: string[]
+  private ignoreMajorPackages: string[]
   private maxDepth: number
 
   private readonly batchSize = 10
@@ -64,6 +65,7 @@ export class PackageDetector {
     this.excludePatterns = options?.excludePatterns || []
     this.scanDirs = options?.scanDirs || []
     this.ignorePackages = options?.ignorePackages || []
+    this.ignoreMajorPackages = options?.ignoreMajorPackages || []
     this.maxDepth = options?.maxDepth ?? 10
     this.adaptive = options?.adaptive ?? true
     this.concurrency = options?.concurrency
@@ -443,10 +445,24 @@ export class PackageDetector {
         const latestClean = semver.coerce(latestVersion)?.version || latestVersion
 
         const hasRangeUpdate = minorClean !== null && minorClean !== installedClean
-        const hasMajorUpdate =
+        let hasMajorUpdate =
           semver.valid(latestClean) !== null &&
           semver.valid(installedClean) !== null &&
           semver.major(latestClean) > semver.major(installedClean)
+
+        // .inuprc ignoreMajor: majors for matched packages are never offered.
+        // A package whose only update is a new major counts as up to date;
+        // in-range minor/patch updates still surface normally.
+        let majorIgnored = false
+        if (
+          hasMajorUpdate &&
+          this.ignoreMajorPackages.length > 0 &&
+          isPackageIgnored(dep.name, this.ignoreMajorPackages)
+        ) {
+          majorIgnored = true
+          hasMajorUpdate = false
+        }
+
         const isOutdated = hasRangeUpdate || hasMajorUpdate
 
         if (isOutdated) {
@@ -473,6 +489,7 @@ export class PackageDetector {
           isOutdated,
           hasRangeUpdate,
           hasMajorUpdate,
+          majorIgnored,
           allVersions,
           deprecated: packageData.deprecated,
           enginesNode: packageData.enginesNode,

--- a/src/shared/config/project-config.ts
+++ b/src/shared/config/project-config.ts
@@ -14,6 +14,13 @@ export interface InupProjectConfig {
   ignore?: string[]
 
   /**
+   * Packages whose major updates are suppressed. Minor/patch updates still
+   * show; a package whose only available update is a new major is treated as
+   * up to date. Same pattern syntax as `ignore`.
+   */
+  ignoreMajor?: string[]
+
+  /**
    * Exclude directory patterns (regex patterns)
    */
   exclude?: string[]
@@ -93,6 +100,12 @@ function normalizeConfig(config: InupProjectConfig): InupProjectConfig {
   if (config.ignore) {
     if (Array.isArray(config.ignore)) {
       normalized.ignore = config.ignore.filter((item) => typeof item === 'string')
+    }
+  }
+
+  if (config.ignoreMajor) {
+    if (Array.isArray(config.ignoreMajor)) {
+      normalized.ignoreMajor = config.ignoreMajor.filter((item) => typeof item === 'string')
     }
   }
 

--- a/src/shared/types/domain.ts
+++ b/src/shared/types/domain.ts
@@ -27,6 +27,7 @@ export interface PackageInfo {
   isOutdated: boolean
   hasRangeUpdate: boolean // If range version is different from current
   hasMajorUpdate: boolean // If latest version is a major update
+  majorIgnored?: boolean // Major update exists but is suppressed by .inuprc ignoreMajor
   description?: string // Package description from npm registry
   homepage?: string // Package homepage URL
   repository?: string // GitHub/repository URL for releases
@@ -103,6 +104,7 @@ export interface UpgradeOptions extends VulnerabilityDisplayOptions {
   maxDepth?: number // Maximum package.json scan depth, defaults to 10
   packageManager?: PackageManager // Manual override for package manager
   ignorePackages?: string[] // Package names/patterns to ignore (from .inuprc or --ignore flag)
+  ignoreMajorPackages?: string[] // Patterns whose major updates are suppressed (from .inuprc ignoreMajor)
   debug?: boolean // Write verbose debug log to /tmp/inup-debug-YYYY-MM-DD.log
   saveExact?: boolean // Write bare versions instead of preserving the range prefix (^/~)
   adaptive?: boolean // Adaptive registry concurrency. Defaults to true.

--- a/test/unit/features/headless/headless-runner.test.ts
+++ b/test/unit/features/headless/headless-runner.test.ts
@@ -291,6 +291,42 @@ describe('HeadlessRunner.run', () => {
       logSpy.mockRestore()
     })
 
+    it('target=latest holds ignoreMajor packages to their in-range bump', async () => {
+      // Detector-level suppression already cleared hasMajorUpdate and set
+      // majorIgnored; latest must not resurrect the major via latestVersion.
+      const majorIgnored = {
+        ...OUTDATED,
+        name: '@tiptap/core',
+        hasMajorUpdate: false,
+        majorIgnored: true,
+      }
+      mocks.getOutdatedPackages.mockResolvedValue([majorIgnored])
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      await new HeadlessRunner({ cwd: '/repo' }).run({ apply: true, target: 'latest' })
+
+      const choices = mocks.upgradePackages.mock.calls[0][0]
+      expect(choices).toHaveLength(1)
+      expect(choices[0]).toMatchObject({ name: '@tiptap/core', targetVersion: '^0.27.2' })
+      logSpy.mockRestore()
+    })
+
+    it('target=latest skips ignoreMajor packages without an in-range bump', async () => {
+      const suppressedMajorOnly = {
+        ...MAJOR_ONLY,
+        isOutdated: false,
+        hasMajorUpdate: false,
+        majorIgnored: true,
+      }
+      mocks.getOutdatedPackages.mockResolvedValue([suppressedMajorOnly])
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      await new HeadlessRunner({ cwd: '/repo' }).run({ apply: true, target: 'latest' })
+
+      expect(mocks.upgradePackages).not.toHaveBeenCalled()
+      logSpy.mockRestore()
+    })
+
     it('--save-exact writes bare versions without the range prefix', async () => {
       mocks.getOutdatedPackages.mockResolvedValue([OUTDATED])
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})

--- a/test/unit/features/headless/headless-runner.test.ts
+++ b/test/unit/features/headless/headless-runner.test.ts
@@ -312,13 +312,22 @@ describe('HeadlessRunner.run', () => {
     })
 
     it('target=latest skips ignoreMajor packages without an in-range bump', async () => {
+      // Normally the detector already drops these from the outdated set
+      // (isOutdated=false); keep them outdated here to pin the defensive
+      // branch in resolveTargetVersion itself.
       const suppressedMajorOnly = {
         ...MAJOR_ONLY,
-        isOutdated: false,
         hasMajorUpdate: false,
         majorIgnored: true,
       }
-      mocks.getOutdatedPackages.mockResolvedValue([suppressedMajorOnly])
+      const suppressedEmptyRange = {
+        ...OUTDATED,
+        name: 'no-range-data',
+        rangeVersion: '',
+        hasMajorUpdate: false,
+        majorIgnored: true,
+      }
+      mocks.getOutdatedPackages.mockResolvedValue([suppressedMajorOnly, suppressedEmptyRange])
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
       await new HeadlessRunner({ cwd: '/repo' }).run({ apply: true, target: 'latest' })

--- a/test/unit/features/headless/report.test.ts
+++ b/test/unit/features/headless/report.test.ts
@@ -44,6 +44,16 @@ describe('buildHeadlessReport', () => {
     expect(report.outdated[0]).not.toHaveProperty('catalog')
   })
 
+  it('flags ignoreMajor-suppressed entries and omits the flag otherwise', () => {
+    const suppressed = makePackageInfo({ hasMajorUpdate: false, majorIgnored: true })
+    const normal = makePackageInfo({ name: 'plain' })
+
+    const report = buildHeadlessReport([suppressed, normal], [suppressed, normal], new Map())
+
+    expect(report.outdated[0]).toMatchObject({ majorIgnored: true, hasMajorUpdate: false })
+    expect(report.outdated[1]).not.toHaveProperty('majorIgnored')
+  })
+
   it('includes the pnpm catalog for catalog-sourced entries', () => {
     const pkg = makePackageInfo({
       packageJsonPath: '/repo/pnpm-workspace.yaml',
@@ -81,6 +91,19 @@ describe('renderPlainReport', () => {
     const text = renderPlainReport([pkg], new Map())
 
     expect(text).toContain('test-pkg')
+    expect(text).not.toContain('(major)')
+  })
+
+  it('points the arrow at the in-range target for ignoreMajor-suppressed entries', () => {
+    const pkg = makePackageInfo({
+      hasMajorUpdate: false,
+      majorIgnored: true,
+      rangeVersion: '1.2.0',
+    })
+
+    const text = renderPlainReport([pkg], new Map())
+
+    expect(text).toContain('test-pkg  ^1.0.0 → 1.2.0  [dependencies]')
     expect(text).not.toContain('(major)')
   })
 

--- a/test/unit/features/upgrade/package-detector.test.ts
+++ b/test/unit/features/upgrade/package-detector.test.ts
@@ -617,6 +617,131 @@ describe('PackageDetector edge paths', () => {
     expect(packages.map((pkg) => pkg.name)).toEqual(['zod'])
   })
 
+  it('treats a package as up to date when ignoreMajor suppresses its only update', async () => {
+    const { isPackageIgnored } = await import('../../../../src/shared/config')
+    vi.mocked(isPackageIgnored).mockImplementation((name: string, patterns: string[]) =>
+      patterns.includes(name)
+    )
+    try {
+      mocks.collectAllDependenciesAsync.mockResolvedValue([dep('@tiptap/core', '^2.0.0')])
+      // No in-range update: the only available bump crosses the major boundary.
+      mocks.findClosestMinorVersion.mockImplementation(() => null)
+      mocks.fetchPackageVersions.mockImplementation(
+        async (packageNames: string[], options: { onBatchReady: (batch: any[]) => void }) => {
+          const data = { latestVersion: '3.0.0', allVersions: ['3.0.0', '2.0.0'] }
+          options.onBatchReady([
+            {
+              packageName: '@tiptap/core',
+              data,
+              completed: 1,
+              total: 1,
+              batchIndex: 0,
+              itemIndex: 0,
+            },
+          ])
+          return new Map(packageNames.map((name) => [name, data]))
+        }
+      )
+
+      const detector = new PackageDetector({
+        cwd: '/repo',
+        ignoreMajorPackages: ['@tiptap/core'],
+      })
+      const packages = await detector.getOutdatedPackages()
+
+      expect(packages).toHaveLength(1)
+      expect(packages[0]).toMatchObject({
+        name: '@tiptap/core',
+        isOutdated: false,
+        hasRangeUpdate: false,
+        hasMajorUpdate: false,
+        majorIgnored: true,
+        latestVersion: '3.0.0',
+      })
+    } finally {
+      vi.mocked(isPackageIgnored).mockImplementation(() => false)
+    }
+  })
+
+  it('keeps the in-range update visible when ignoreMajor suppresses the major', async () => {
+    const { isPackageIgnored } = await import('../../../../src/shared/config')
+    vi.mocked(isPackageIgnored).mockImplementation((name: string, patterns: string[]) =>
+      patterns.includes(name)
+    )
+    try {
+      mocks.collectAllDependenciesAsync.mockResolvedValue([dep('@tiptap/core', '^2.0.0')])
+      mocks.findClosestMinorVersion.mockImplementation(() => '2.6.0')
+      mocks.fetchPackageVersions.mockImplementation(
+        async (packageNames: string[], options: { onBatchReady: (batch: any[]) => void }) => {
+          const data = { latestVersion: '3.0.0', allVersions: ['3.0.0', '2.6.0', '2.0.0'] }
+          options.onBatchReady([
+            {
+              packageName: '@tiptap/core',
+              data,
+              completed: 1,
+              total: 1,
+              batchIndex: 0,
+              itemIndex: 0,
+            },
+          ])
+          return new Map(packageNames.map((name) => [name, data]))
+        }
+      )
+
+      const detector = new PackageDetector({
+        cwd: '/repo',
+        ignoreMajorPackages: ['@tiptap/core'],
+      })
+      const packages = await detector.getOutdatedPackages()
+
+      expect(packages[0]).toMatchObject({
+        isOutdated: true,
+        hasRangeUpdate: true,
+        rangeVersion: '2.6.0',
+        hasMajorUpdate: false,
+        majorIgnored: true,
+        latestVersion: '3.0.0',
+      })
+    } finally {
+      vi.mocked(isPackageIgnored).mockImplementation(() => false)
+    }
+  })
+
+  it('leaves majors intact for packages ignoreMajor does not match', async () => {
+    const { isPackageIgnored } = await import('../../../../src/shared/config')
+    vi.mocked(isPackageIgnored).mockImplementation((name: string, patterns: string[]) =>
+      patterns.includes(name)
+    )
+    try {
+      mocks.collectAllDependenciesAsync.mockResolvedValue([dep('react', '^17.0.0')])
+      mocks.findClosestMinorVersion.mockImplementation(() => null)
+      mocks.fetchPackageVersions.mockImplementation(
+        async (packageNames: string[], options: { onBatchReady: (batch: any[]) => void }) => {
+          const data = { latestVersion: '18.0.0', allVersions: ['18.0.0', '17.0.0'] }
+          options.onBatchReady([
+            { packageName: 'react', data, completed: 1, total: 1, batchIndex: 0, itemIndex: 0 },
+          ])
+          return new Map(packageNames.map((name) => [name, data]))
+        }
+      )
+
+      const detector = new PackageDetector({
+        cwd: '/repo',
+        ignoreMajorPackages: ['@tiptap/core'],
+      })
+      const packages = await detector.getOutdatedPackages()
+
+      expect(packages[0]).toMatchObject({
+        name: 'react',
+        isOutdated: true,
+        hasMajorUpdate: true,
+        majorIgnored: false,
+      })
+    } finally {
+      vi.mocked(isPackageIgnored).mockImplementation(() => false)
+    }
+  })
+
   it('sorts scoped packages before unscoped ones', async () => {
     mocks.collectAllDependenciesAsync.mockResolvedValue([
       dep('zod', '^1.0.0'),

--- a/test/unit/shared/config/project-config.test.ts
+++ b/test/unit/shared/config/project-config.test.ts
@@ -100,6 +100,27 @@ describe('project-config', () => {
       expect(config.ignore).toEqual(['valid', 'also-valid', 'still-valid'])
     })
 
+    it('should load ignoreMajor patterns', () => {
+      writeFileSync(
+        join(testDir, '.inuprc'),
+        JSON.stringify({ ignoreMajor: ['@tiptap/*', 'react'] })
+      )
+
+      const config = loadProjectConfig(testDir)
+      expect(config.ignoreMajor).toEqual(['@tiptap/*', 'react'])
+    })
+
+    it('drops a non-array ignoreMajor field and filters non-string entries', () => {
+      writeFileSync(join(testDir, '.inuprc'), JSON.stringify({ ignoreMajor: '@tiptap/*' }))
+      expect(loadProjectConfig(testDir).ignoreMajor).toBeUndefined()
+
+      writeFileSync(
+        join(testDir, '.inuprc'),
+        JSON.stringify({ ignoreMajor: ['@tiptap/*', 42, null] })
+      )
+      expect(loadProjectConfig(testDir).ignoreMajor).toEqual(['@tiptap/*'])
+    })
+
     it('should load showPeerDependencyVulnerabilities when set to a boolean', () => {
       writeFileSync(
         join(testDir, '.inuprc'),

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -2,7 +2,7 @@
 title: Configuration
 description: The .inuprc file — ignore packages with globs, exclude directories, extend the scan list, and control vulnerability display.
 order: 40
-updated: 2026-07-06
+updated: 2026-07-27
 ---
 
 inup needs no configuration to run. When you want persistent project rules, add a JSON config file. inup looks for the first of these, searching from the working directory upward to the filesystem root:
@@ -18,6 +18,7 @@ Every mode honors it — the interactive picker, `--json`, `--check` and `--appl
 ```json
 {
   "ignore": ["@babel/*", "eslint-*", "typescript"],
+  "ignoreMajor": ["@tiptap/*"],
   "exclude": ["fixtures", "examples/.*"],
   "scanDirs": ["lib"],
   "showPeerDependencyVulnerabilities": false,
@@ -36,6 +37,20 @@ Packages to skip during upgrade checks. Supports exact names and glob patterns:
 - `"eslint-*"` — wildcard, `*` matches any sequence, `?` matches one character
 
 The same syntax works ad hoc via `--ignore` on the command line.
+
+### `ignoreMajor`
+
+Packages whose **major** updates are suppressed — minor and patch updates still show. Same pattern syntax as `ignore`. Use it for dependencies you deliberately keep on their current major (a UI kit mid-migration, a framework pinned by a peer range) without losing sight of safe in-range bumps.
+
+- A package whose only available update is a new major is treated as up to date.
+- When an in-range update exists, the package shows with the in-range target; the major is never offered — the interactive picker won't select it, and `--apply --target latest` holds the package to its in-range bump.
+- `--json` reports such entries with `"hasMajorUpdate": false` and `"majorIgnored": true` (the `latest` field stays truthful).
+
+```json
+{
+  "ignoreMajor": ["@tiptap/*"]
+}
+```
 
 ### `exclude`
 


### PR DESCRIPTION
## What

New `.inuprc` key **`ignoreMajor`** — packages matched by these patterns (same glob syntax as `ignore`) never get major updates offered, while minor/patch updates keep flowing.

```json
{
  "ignoreMajor": ["@tiptap/*"]
}
```

## Semantics

- Only-major update available → package treated as **up to date** (hidden from the list, `--check` passes).
- In-range update + major available → package shows with the **in-range target**; the major is never offered.
- `--apply --target latest` holds matched packages to their in-range bump.
- `--json`: `hasMajorUpdate: false` + `majorIgnored: true`; the `latest` field stays truthful. Plain report arrow points at the in-range target.

## How

Suppression happens once in `PackageDetector.resolvePackageGroup` (the single choke point), so TUI, `--json`, `--check`, `--apply`, and the GitHub Action all inherit it. New optional `majorIgnored` flag on `PackageInfo` lets the headless `latest` target respect it without lying about the latest version.

## Tests

- `project-config`: key loading/normalization.
- `package-detector`: major-only suppressed, in-range kept, non-matched untouched.
- `headless-runner`: `--target latest` capped to range / skipped without range.

1231 tests green, typecheck + biome clean.